### PR TITLE
ignore some notes when buildings packages

### DIFF
--- a/R/buildLibrary.R
+++ b/R/buildLibrary.R
@@ -76,7 +76,7 @@ buildLibrary<-function(lib=".",cran=TRUE, update_type=NULL){
   for(aw in accepted_warnings) {
     ck$warnings <- grep(aw, ck$warnings, value=TRUE,invert=TRUE)
   }
-  accepted_notes <- c("checking package dependencies ... NOTE\nImports includes '.*' non-default packages.\nImporting from so many packages makes the package vulnerable to any of\nthem becoming unavailable.  Move as many as possible to Suggests and\nuse conditionally.")
+  accepted_notes <- c("checking package dependencies ... NOTE\nImports includes \\d+ non-default packages.\nImporting from so many packages makes the package vulnerable to any of\nthem becoming unavailable.  Move as many as possible to Suggests and\nuse conditionally.")
   for(aw in accepted_notes) {
     ck$notes <- grep(aw, ck$notes, value=TRUE,invert=TRUE)
   }

--- a/R/buildLibrary.R
+++ b/R/buildLibrary.R
@@ -76,6 +76,10 @@ buildLibrary<-function(lib=".",cran=TRUE, update_type=NULL){
   for(aw in accepted_warnings) {
     ck$warnings <- grep(aw, ck$warnings, value=TRUE,invert=TRUE)
   }
+  accepted_notes <- c("checking package dependencies ... NOTE\nImports includes '.*' non-default packages.\nImporting from so many packages makes the package vulnerable to any of\nthem becoming unavailable. Move as many as possible to Suggests and\nuse conditionally.")
+  for(aw in accepted_notes) {
+    ck$notes <- grep(aw, ck$notes, value=TRUE,invert=TRUE)
+  }
   print(ck)
   
   if(length(ck$errors)>0) {

--- a/R/buildLibrary.R
+++ b/R/buildLibrary.R
@@ -76,7 +76,7 @@ buildLibrary<-function(lib=".",cran=TRUE, update_type=NULL){
   for(aw in accepted_warnings) {
     ck$warnings <- grep(aw, ck$warnings, value=TRUE,invert=TRUE)
   }
-  accepted_notes <- c("checking package dependencies ... NOTE\nImports includes '.*' non-default packages.\nImporting from so many packages makes the package vulnerable to any of\nthem becoming unavailable. Move as many as possible to Suggests and\nuse conditionally.")
+  accepted_notes <- c("checking package dependencies ... NOTE\nImports includes '.*' non-default packages.\nImporting from so many packages makes the package vulnerable to any of\nthem becoming unavailable.  Move as many as possible to Suggests and\nuse conditionally.")
   for(aw in accepted_notes) {
     ck$notes <- grep(aw, ck$notes, value=TRUE,invert=TRUE)
   }


### PR DESCRIPTION
Too many dependencies in a package create a note from R>4.0 on. This note does not preclude building the package with lucode2 anymore