### PR TITLE
add character string update_type parameters

### DIFF
--- a/.zenodo.json
+++ b/.zenodo.json
@@ -1,6 +1,6 @@
 {
   "title": "lucode2: Code Manipulation and Analysis Tools",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "description": "<p>A collection of tools which allow to manipulate and analyze code.<\/p>",
   "creators": [
     {

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Package: lucode2
 Type: Package
 Title: Code Manipulation and Analysis Tools
-Version: 0.2.0
-Date: 2020-07-07
+Version: 0.3.0
+Date: 2020-08-05
 Authors@R: c(person("Jan Philipp", "Dietrich", email = "dietrich@pik-potsdam.de", role = c("aut","cre")),
              person("David", "Klein", role = "aut"),
              person("Anastasis", "Giannousakis", role = "aut"),
@@ -18,4 +18,4 @@ License: BSD_2_clause + file LICENSE
 LazyData: no
 Encoding: UTF-8
 RoxygenNote: 7.1.1
-ValidationKey: 369000
+ValidationKey: 554370

--- a/R/buildLibrary.R
+++ b/R/buildLibrary.R
@@ -12,7 +12,17 @@
 #' 
 #' @param lib Path to the package
 #' @param cran If cran-like test is needed
-#' @param update_type 1 if the update is a major revision, 2 (default) for minor, 3 for patch, 4 only for packages in development stage
+#' @param update_type Either an integer or character string:
+#' 
+#'   | **number**  | **string**    | **description**                          |
+#'   |-------------|---------------|------------------------------------------|
+#'   | 1           | `major`       | for major rewrite of the whole package   |
+#'   | 2 (default) | `minor`       | for new features or improvements         |
+#'   | 3           | `patch`       | for bugfixes and corrections             |
+#'   | 4           | `development` | only for packages in development stage   |
+#' 
+#' @md
+#' 
 #' @author Jan Philipp Dietrich, Anastasis Giannousakis, Markus Bonsch
 #' @seealso \code{\link{package2readme}}
 #' @importFrom citation package2zenodo
@@ -130,7 +140,19 @@ buildLibrary<-function(lib=".",cran=TRUE, update_type=NULL){
     if (any(!(identifier %in% (1:length(update_type)-1)))) stop("This choice (",identifier,") is not possible. Please type in a number between 0 and ",length(update_type)-1)
     return(identifier)
   }
-  if (is.null(update_type)) update_type <- choose_module(".")
+  
+  if (is.null(update_type)) {
+    update_type <- choose_module(".")
+  } else {
+    # convert character update_type parameters to numbers
+    update_type <- switch(as.character(update_type),
+           'major' = 1,       '1' = 1,
+           'minor' = 2,       '2' = 2,
+           'patch' = 3,       '3' = 3,
+           'development' = 4, '4' = 4,
+           # default
+           choose_module('.'))
+  }
   version <- autoversion(version,update_type)
   
   #Change the version in descfile

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Code Manipulation and Analysis Tools
 
-R package **lucode2**, version **0.1.2**
+R package **lucode2**, version **0.3.0**
 
 [![Travis build status](https://travis-ci.com/pik-piam/lucode2.svg?branch=master)](https://travis-ci.com/pik-piam/lucode2)  [![codecov](https://codecov.io/gh/pik-piam/lucode2/branch/master/graph/badge.svg)](https://codecov.io/gh/pik-piam/lucode2)
 
@@ -38,8 +38,8 @@ In case of questions / problems please contact Jan Philipp Dietrich <dietrich@pi
 
 To cite package **lucode2** in publications use:
 
-Dietrich J, Klein D, Giannousakis A, Bonsch M, Bodirsky B, Baumstark L (2020). _lucode2: Code Manipulation and Analysis Tools_. R
-package version 0.1.2.
+Dietrich J, Klein D, Giannousakis A, Bonsch M, Bodirsky B, Baumstark L (2020). _lucode2: Code
+Manipulation and Analysis Tools_. R package version 0.3.0.
 
 A BibTeX entry for LaTeX users is
 
@@ -48,7 +48,7 @@ A BibTeX entry for LaTeX users is
   title = {lucode2: Code Manipulation and Analysis Tools},
   author = {Jan Philipp Dietrich and David Klein and Anastasis Giannousakis and Markus Bonsch and Benjamin Leon Bodirsky and Lavinia Baumstark},
   year = {2020},
-  note = {R package version 0.1.2},
+  note = {R package version 0.3.0},
 }
 ```
 


### PR DESCRIPTION
I'm always calling `lucode::buildlibrary()` from the console history, but mix up the `update_types`.  Named update types would save me a couple of package build per week ;)