### PR TITLE
Better linter/auto-formatter workflow

### DIFF
--- a/.buildlibrary
+++ b/.buildlibrary
@@ -1,4 +1,4 @@
-ValidationKey: '0987'
+ValidationKey: '2270807'
 AcceptedWarnings:
 - 'Warning: package ''.*'' was built under R version'
 - 'Warning: namespace ''.*'' is not available and has been replaced'
@@ -6,4 +6,3 @@ AcceptedNotes: unable to verify current time
 AutocreateReadme: yes
 UseGithubActions: yes
 allowLinterWarnings: no
-

--- a/.buildlibrary
+++ b/.buildlibrary
@@ -1,4 +1,4 @@
-ValidationKey: '2290184'
+ValidationKey: '2308956'
 AcceptedWarnings:
 - 'Warning: package ''.*'' was built under R version'
 - 'Warning: namespace ''.*'' is not available and has been replaced'

--- a/.buildlibrary
+++ b/.buildlibrary
@@ -1,4 +1,4 @@
-ValidationKey: '2270807'
+ValidationKey: '0987'
 AcceptedWarnings:
 - 'Warning: package ''.*'' was built under R version'
 - 'Warning: namespace ''.*'' is not available and has been replaced'
@@ -6,3 +6,4 @@ AcceptedNotes: unable to verify current time
 AutocreateReadme: yes
 UseGithubActions: yes
 allowLinterWarnings: no
+

--- a/.buildlibrary
+++ b/.buildlibrary
@@ -1,4 +1,4 @@
-ValidationKey: '2252040'
+ValidationKey: '2270807'
 AcceptedWarnings:
 - 'Warning: package ''.*'' was built under R version'
 - 'Warning: namespace ''.*'' is not available and has been replaced'

--- a/.buildlibrary
+++ b/.buildlibrary
@@ -1,4 +1,4 @@
-ValidationKey: '2270807'
+ValidationKey: '2290184'
 AcceptedWarnings:
 - 'Warning: package ''.*'' was built under R version'
 - 'Warning: namespace ''.*'' is not available and has been replaced'

--- a/.zenodo.json
+++ b/.zenodo.json
@@ -1,6 +1,6 @@
 {
   "title": "lucode2: Code Manipulation and Analysis Tools",
-  "version": "0.12.0",
+  "version": "0.12.1",
   "description": "<p>A collection of tools which allow to manipulate and analyze code.<\/p>",
   "creators": [
     {

--- a/.zenodo.json
+++ b/.zenodo.json
@@ -1,6 +1,6 @@
 {
   "title": "lucode2: Code Manipulation and Analysis Tools",
-  "version": "0.12.1",
+  "version": "0.12.2",
   "description": "<p>A collection of tools which allow to manipulate and analyze code.<\/p>",
   "creators": [
     {

--- a/.zenodo.json
+++ b/.zenodo.json
@@ -1,6 +1,6 @@
 {
   "title": "lucode2: Code Manipulation and Analysis Tools",
-  "version": "0.12.2",
+  "version": "0.12.3",
   "description": "<p>A collection of tools which allow to manipulate and analyze code.<\/p>",
   "creators": [
     {

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Package: lucode2
 Type: Package
 Title: Code Manipulation and Analysis Tools
-Version: 0.12.1
-Date: 2021-05-20
+Version: 0.12.2
+Date: 2021-05-25
 Authors@R: c(person("Jan Philipp", "Dietrich", email = "dietrich@pik-potsdam.de", role = c("aut","cre")),
              person("David", "Klein", role = "aut"),
              person("Anastasis", "Giannousakis", role = "aut"),

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: lucode2
 Type: Package
 Title: Code Manipulation and Analysis Tools
-Version: 0.12.2
+Version: 0.12.3
 Date: 2021-05-25
 Authors@R: c(person("Jan Philipp", "Dietrich", email = "dietrich@pik-potsdam.de", role = c("aut","cre")),
              person("David", "Klein", role = "aut"),

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: lucode2
 Type: Package
 Title: Code Manipulation and Analysis Tools
-Version: 0.12.0
+Version: 0.12.1
 Date: 2021-05-20
 Authors@R: c(person("Jan Philipp", "Dietrich", email = "dietrich@pik-potsdam.de", role = c("aut","cre")),
              person("David", "Klein", role = "aut"),

--- a/R/autoFormat.R
+++ b/R/autoFormat.R
@@ -2,7 +2,9 @@
 #'
 #' Apply auto-formatting using styler::style_file to the given files.
 #'
-#' @param filesToAutoFormat A character vector of paths to files that should be auto-formatted.
+#' @param files A character vector of paths to files that should be auto-formatted.
+#' @param ignoreLintFreeFiles If set to TRUE only files with linter warnings are auto-formatted.
+#' @param lintAfterwards If set to TRUE return linter results of the auto-formatted files.
 #'
 #' @author Pascal Führlich
 #' @seealso \code{\link{getFilesToLint}}
@@ -12,6 +14,12 @@
 #' lucode2::autoFormat()
 #' }
 #' @export
-autoFormat <- function(filesToAutoFormat = getFilesToLint()) {
-  style_file(filesToAutoFormat)
+autoFormat <- function(files = getFilesToLint(), ignoreLintFreeFiles = TRUE, lintAfterwards = TRUE) {
+  if (ignoreLintFreeFiles) {
+    files <- files[sapply(files, function(aFile) length(lint(aFile)) > 0)]
+  }
+  style_file(files)
+  if (lintAfterwards) {
+    return(lint(files))
+  }
 }

--- a/R/autoFormat.R
+++ b/R/autoFormat.R
@@ -18,7 +18,7 @@ autoFormat <- function(files = getFilesToLint(), ignoreLintFreeFiles = TRUE, lin
   if (ignoreLintFreeFiles) {
     files <- files[sapply(files, function(aFile) length(lint(aFile)) > 0)]
   }
-  style_file(files)
+  style_file(files, strict = FALSE)
   if (lintAfterwards) {
     return(lint(files))
   }

--- a/R/buildLibrary.R
+++ b/R/buildLibrary.R
@@ -280,6 +280,7 @@ buildLibrary <- function(lib = ".", cran = TRUE, updateType = NULL, gitpush = FA
   # Update validation key
   ############################################################
   if (cran) {
+    ununsue <- 1
     cfg$ValidationKey <- as.character(validationkey(version, dateToday))  # nolint
   } else {
     cfg$ValidationKey <- as.character(0)  # nolint

--- a/R/buildLibrary.R
+++ b/R/buildLibrary.R
@@ -280,7 +280,6 @@ buildLibrary <- function(lib = ".", cran = TRUE, updateType = NULL, gitpush = FA
   # Update validation key
   ############################################################
   if (cran) {
-    ununsue <- 1
     cfg$ValidationKey <- as.character(validationkey(version, dateToday))  # nolint
   } else {
     cfg$ValidationKey <- as.character(0)  # nolint

--- a/R/buildLibrary.R
+++ b/R/buildLibrary.R
@@ -3,12 +3,13 @@
 #' Builds R libraries. Includes checks for consistency.
 #'
 #' This function is designed to help building R libraries. It performs the
-#' following steps: \itemize{ \item Version: Determination
-#' of a new version number (Can also be defined by the user). \item Date:
-#' Determination of a the date of the build (Can also be defined by the user).
+#' following steps: \itemize{
+#' \item Version: Determination of a new version number (Can also be defined by the user).
+#' \item Date: Determination of a the date of the build (Can also be defined by the user).
 #' \item R check: Check whether the library is consistent and can be built.
-#' \item Package building Builds the .zip and .tar.gz packages under windows.
-#' Under linux, only the .tar.gz package is built. } The commit has to be performed by the user still.
+#' \item Package building: Builds the .zip and .tar.gz packages under windows.
+#' Under linux, only the .tar.gz package is built. }
+#' The commit has to be performed by the user still.
 #'
 #' @param lib Path to the package
 #' @param cran If cran-like test is needed
@@ -268,20 +269,18 @@ buildLibrary <- function(lib = ".", cran = TRUE, updateType = NULL, gitpush = FA
   ############################################################
   # Check for the date
   ############################################################
+  dateToday <- Sys.Date()
   if (any(grepl("Date:", descfile))) {
-    descfileDate <- sub(pattern = "[^(0-9)]*$", replacement = "", perl = TRUE,
-                         x = sub(pattern = "Date:[^(0-9)]*", replacement = "", perl = TRUE,
-                                 x = grep(pattern = "Date:", x = descfile, value = TRUE)))
-    date <- Sys.Date()
-    # Change the date in descfile
-    descfile[grep("Date:", descfile)] <- sub(descfileDate, date, descfile[grep("Date:", descfile)])
+    descfile[grep("Date:", descfile)] <- paste("Date:", dateToday)
+  } else {
+    descfile <- append(descfile, paste("Date:", dateToday))
   }
 
   ############################################################
   # Update validation key
   ############################################################
   if (cran) {
-    cfg$ValidationKey <- as.character(validationkey(version, date))  # nolint
+    cfg$ValidationKey <- as.character(validationkey(version, dateToday))  # nolint
   } else {
     cfg$ValidationKey <- as.character(0)  # nolint
   }

--- a/R/getFilesToLint.R
+++ b/R/getFilesToLint.R
@@ -16,7 +16,8 @@ getFilesToLint <- function() {
   recentlyChanged <- substring(system("git status --porcelain", intern = TRUE), 4)
 
   gitRootPath <- system("git rev-parse --show-toplevel", intern = TRUE)
-  lastVersionTime <- system(paste0('git log -1 --format=format:"%aD" "', gitRootPath, '/.buildlibrary"'), intern = TRUE)
+  lastVersionTime <- system(paste0('git log -1 --format=format:"%at" "', gitRootPath, '/.buildlibrary"'), intern = TRUE)
+  lastVersionTime <- as.double(lastVersionTime) + 1  # add 1 second, we want only commits that are actually newer
   gitUserMail <- system("git config user.email", intern = TRUE)
 
   # files changed in any non-merge commit authored by current git user since the last version

--- a/R/lint.R
+++ b/R/lint.R
@@ -5,9 +5,8 @@
 #' Returns a named list, where the names are the paths to the linted files and the values are lists containing the
 #' linter warnings.
 #'
-#' @param filesToLint A character vector of paths to files that should be checked by the linter. If filesToLint = "."
+#' @param files A character vector of paths to files that should be checked by the linter. If set to "."
 #' the whole package is linted.
-#' @param stopAfterFirstWarning Set to TRUE if the linter should stop after finding a warning.
 #'
 #' @author Pascal Führlich
 #' @seealso \code{\link{getFilesToLint}}, \code{\link{autoFormat}}, \code{\link[lintr]{lint}}
@@ -15,21 +14,21 @@
 #' @examples
 #' lucode2::lint()
 #' @export
-lint <- function(filesToLint = getFilesToLint(), stopAfterFirstWarning = FALSE) {
-  linters <- lintr::with_defaults(line_length_linter = lintr::line_length_linter(120),
-                                  object_name_linter = lintr::object_name_linter(styles = "camelCase"),
-                                  cyclocomp_linter = NULL)
-  if (identical(filesToLint, ".")) {
+lint <- function(files = getFilesToLint()) {
+  linters <- lintr::with_defaults(
+    line_length_linter = lintr::line_length_linter(120),
+    object_name_linter = lintr::object_name_linter(styles = "camelCase"),
+    cyclocomp_linter = NULL
+  )
+
+  if (identical(files, ".")) {
     return(lint_package(linters = linters))
   }
-  linterWarnings <- NULL
-  for (fileToLint in filesToLint) {
-    cat('Running lucode2::lint("', fileToLint, '")\n', sep = "")
-    linterWarnings <- append(linterWarnings, lintr::lint(fileToLint, linters = linters))
-    if (stopAfterFirstWarning && length(linterWarnings) > 0) {
-      break
-    }
-  }
+
+  linterWarnings <- sapply(files, function(aFile) {
+    cat('Running lucode2::lint("', aFile, '")\n', sep = "")
+    return(lintr::lint(aFile, linters = linters))
+  })
 
   # combine the results of multiple calls to lintr::lint, taken from lintr:::flatten_lints
   .flattenLints <- function(x) {

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Code Manipulation and Analysis Tools
 
-R package **lucode2**, version **0.12.0**
+R package **lucode2**, version **0.12.1**
 
 [![CRAN status](https://www.r-pkg.org/badges/version/lucode2)](https://cran.r-project.org/package=lucode2) [![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.4389418.svg)](https://doi.org/10.5281/zenodo.4389418)  [![R build status](https://github.com/pik-piam/lucode2/workflows/check/badge.svg)](https://github.com/pik-piam/lucode2/actions) [![codecov](https://codecov.io/gh/pik-piam/lucode2/branch/master/graph/badge.svg)](https://codecov.io/gh/pik-piam/lucode2)
 
@@ -40,7 +40,7 @@ To cite package **lucode2** in publications use:
 
 Dietrich J, Klein D, Giannousakis A, Bonsch M, Bodirsky B, Baumstark L, Führlich P (2021). _lucode2: Code
 Manipulation and Analysis Tools_. doi: 10.5281/zenodo.4389418 (URL: https://doi.org/10.5281/zenodo.4389418), R
-package version 0.12.0, <URL: https://github.com/pik-piam/lucode2>.
+package version 0.12.1, <URL: https://github.com/pik-piam/lucode2>.
 
 A BibTeX entry for LaTeX users is
 
@@ -49,7 +49,7 @@ A BibTeX entry for LaTeX users is
   title = {lucode2: Code Manipulation and Analysis Tools},
   author = {Jan Philipp Dietrich and David Klein and Anastasis Giannousakis and Markus Bonsch and Benjamin Leon Bodirsky and Lavinia Baumstark and Pascal Führlich},
   year = {2021},
-  note = {R package version 0.12.0},
+  note = {R package version 0.12.1},
   doi = {10.5281/zenodo.4389418},
   url = {https://github.com/pik-piam/lucode2},
 }

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Code Manipulation and Analysis Tools
 
-R package **lucode2**, version **0.12.1**
+R package **lucode2**, version **0.12.2**
 
 [![CRAN status](https://www.r-pkg.org/badges/version/lucode2)](https://cran.r-project.org/package=lucode2) [![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.4389418.svg)](https://doi.org/10.5281/zenodo.4389418)  [![R build status](https://github.com/pik-piam/lucode2/workflows/check/badge.svg)](https://github.com/pik-piam/lucode2/actions) [![codecov](https://codecov.io/gh/pik-piam/lucode2/branch/master/graph/badge.svg)](https://codecov.io/gh/pik-piam/lucode2)
 
@@ -39,8 +39,8 @@ In case of questions / problems please contact Jan Philipp Dietrich <dietrich@pi
 To cite package **lucode2** in publications use:
 
 Dietrich J, Klein D, Giannousakis A, Bonsch M, Bodirsky B, Baumstark L, Führlich P (2021). _lucode2: Code
-Manipulation and Analysis Tools_. doi: 10.5281/zenodo.4389418 (URL: https://doi.org/10.5281/zenodo.4389418), R
-package version 0.12.1, <URL: https://github.com/pik-piam/lucode2>.
+Manipulation and Analysis Tools_. doi: 10.5281/zenodo.4389418 (URL: https://doi.org/10.5281/zenodo.4389418),
+R package version 0.12.2, <URL: https://github.com/pik-piam/lucode2>.
 
 A BibTeX entry for LaTeX users is
 
@@ -49,7 +49,7 @@ A BibTeX entry for LaTeX users is
   title = {lucode2: Code Manipulation and Analysis Tools},
   author = {Jan Philipp Dietrich and David Klein and Anastasis Giannousakis and Markus Bonsch and Benjamin Leon Bodirsky and Lavinia Baumstark and Pascal Führlich},
   year = {2021},
-  note = {R package version 0.12.1},
+  note = {R package version 0.12.2},
   doi = {10.5281/zenodo.4389418},
   url = {https://github.com/pik-piam/lucode2},
 }

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Code Manipulation and Analysis Tools
 
-R package **lucode2**, version **0.12.2**
+R package **lucode2**, version **0.12.3**
 
 [![CRAN status](https://www.r-pkg.org/badges/version/lucode2)](https://cran.r-project.org/package=lucode2) [![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.4389418.svg)](https://doi.org/10.5281/zenodo.4389418)  [![R build status](https://github.com/pik-piam/lucode2/workflows/check/badge.svg)](https://github.com/pik-piam/lucode2/actions) [![codecov](https://codecov.io/gh/pik-piam/lucode2/branch/master/graph/badge.svg)](https://codecov.io/gh/pik-piam/lucode2)
 
@@ -38,10 +38,9 @@ In case of questions / problems please contact Jan Philipp Dietrich <dietrich@pi
 
 To cite package **lucode2** in publications use:
 
-Dietrich J, Klein D, Giannousakis A, Bonsch M, Bodirsky B, Baumstark L,
-Führlich P (2021). _lucode2: Code Manipulation and Analysis Tools_. doi:
-10.5281/zenodo.4389418 (URL: https://doi.org/10.5281/zenodo.4389418), R package
-version 0.12.2, <URL: https://github.com/pik-piam/lucode2>.
+Dietrich J, Klein D, Giannousakis A, Bonsch M, Bodirsky B, Baumstark L, Führlich P (2021). _lucode2: Code
+Manipulation and Analysis Tools_. doi: 10.5281/zenodo.4389418 (URL: https://doi.org/10.5281/zenodo.4389418),
+R package version 0.12.3, <URL: https://github.com/pik-piam/lucode2>.
 
 A BibTeX entry for LaTeX users is
 
@@ -50,7 +49,7 @@ A BibTeX entry for LaTeX users is
   title = {lucode2: Code Manipulation and Analysis Tools},
   author = {Jan Philipp Dietrich and David Klein and Anastasis Giannousakis and Markus Bonsch and Benjamin Leon Bodirsky and Lavinia Baumstark and Pascal Führlich},
   year = {2021},
-  note = {R package version 0.12.2},
+  note = {R package version 0.12.3},
   doi = {10.5281/zenodo.4389418},
   url = {https://github.com/pik-piam/lucode2},
 }


### PR DESCRIPTION
- remove auto-format question in buildLibrary
- show linterResults directly when running buildLibrary
- do not auto-format linter-warning-free files per default
- run linter after auto-formatting per default
- use styler's strict = FALSE -> leaves extra spaces/newlines for better readability intact