### PR TITLE
Add average runtime to pdf.

### DIFF
--- a/.buildlibrary
+++ b/.buildlibrary
@@ -1,4 +1,4 @@
-ValidationKey: '3449810'
+ValidationKey: '3469131'
 AutocreateReadme: yes
 AcceptedWarnings:
 - 'Warning: package ''.*'' was built under R version'

--- a/.zenodo.json
+++ b/.zenodo.json
@@ -1,6 +1,6 @@
 {
   "title": "lucode2: Code Manipulation and Analysis Tools",
-  "version": "0.18.2",
+  "version": "0.18.3",
   "description": "<p>A collection of tools which allow to manipulate and analyze code.<\/p>",
   "creators": [
     {
@@ -22,7 +22,7 @@
       "name": "Baumstark, Lavinia"
     },
     {
-      "name": "FÃ¼hrlich, Pascal"
+      "name": "Führlich, Pascal"
     }
   ]
 }

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Package: lucode2
 Type: Package
 Title: Code Manipulation and Analysis Tools
-Version: 0.18.2
-Date: 2021-11-24
+Version: 0.18.3
+Date: 2021-11-26
 Authors@R: c(person("Jan Philipp", "Dietrich", email = "dietrich@pik-potsdam.de", role = c("aut","cre")),
              person("David", "Klein", role = "aut"),
              person("Anastasis", "Giannousakis", role = "aut"),

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Code Manipulation and Analysis Tools
 
-R package **lucode2**, version **0.18.2**
+R package **lucode2**, version **0.18.3**
 
 [![CRAN status](https://www.r-pkg.org/badges/version/lucode2)](https://cran.r-project.org/package=lucode2) [![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.4389418.svg)](https://doi.org/10.5281/zenodo.4389418) [![R build status](https://github.com/pik-piam/lucode2/workflows/check/badge.svg)](https://github.com/pik-piam/lucode2/actions) [![codecov](https://codecov.io/gh/pik-piam/lucode2/branch/master/graph/badge.svg)](https://codecov.io/gh/pik-piam/lucode2) [![r-universe](https://pik-piam.r-universe.dev/badges/lucode2)](https://pik-piam.r-universe.dev/ui#builds)
 
@@ -38,16 +38,16 @@ In case of questions / problems please contact Jan Philipp Dietrich <dietrich@pi
 
 To cite package **lucode2** in publications use:
 
-Dietrich J, Klein D, Giannousakis A, Bonsch M, Bodirsky B, Baumstark L, FÃ¼hrlich P (2021). _lucode2: Code Manipulation and Analysis Tools_. doi: 10.5281/zenodo.4389418 (URL: https://doi.org/10.5281/zenodo.4389418), R package version 0.18.2, <URL: https://github.com/pik-piam/lucode2>.
+Dietrich J, Klein D, Giannousakis A, Bonsch M, Bodirsky B, Baumstark L, Führlich P (2021). _lucode2: Code Manipulation and Analysis Tools_. doi: 10.5281/zenodo.4389418 (URL: https://doi.org/10.5281/zenodo.4389418), R package version 0.18.3, <URL: https://github.com/pik-piam/lucode2>.
 
 A BibTeX entry for LaTeX users is
 
  ```latex
 @Manual{,
   title = {lucode2: Code Manipulation and Analysis Tools},
-  author = {Jan Philipp Dietrich and David Klein and Anastasis Giannousakis and Markus Bonsch and Benjamin Leon Bodirsky and Lavinia Baumstark and Pascal FÃ¼hrlich},
+  author = {Jan Philipp Dietrich and David Klein and Anastasis Giannousakis and Markus Bonsch and Benjamin Leon Bodirsky and Lavinia Baumstark and Pascal Führlich},
   year = {2021},
-  note = {R package version 0.18.2},
+  note = {R package version 0.18.3},
   doi = {10.5281/zenodo.4389418},
   url = {https://github.com/pik-piam/lucode2},
 }


### PR DESCRIPTION
For coupled REMIND-MAgPIE runs there is a pdf produced showing the runtime of the models across iterations and scenarios. It also displays a short statistic about the runtimes. This PR adds the average runtime of each model across scenarios and iterations to the statistic section.