### PR TITLE
enable empty string and strings containing = in extract_arguments()

### DIFF
--- a/.buildlibrary
+++ b/.buildlibrary
@@ -1,4 +1,4 @@
-ValidationKey: '3571436'
+ValidationKey: '3590622'
 AutocreateReadme: yes
 AcceptedWarnings:
 - 'Warning: package ''.*'' was built under R version'

--- a/.zenodo.json
+++ b/.zenodo.json
@@ -1,6 +1,6 @@
 {
   "title": "lucode2: Code Manipulation and Analysis Tools",
-  "version": "0.18.8",
+  "version": "0.18.9",
   "description": "<p>A collection of tools which allow to manipulate and analyze code.<\/p>",
   "creators": [
     {

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Package: lucode2
 Type: Package
 Title: Code Manipulation and Analysis Tools
-Version: 0.18.8
-Date: 2022-01-05
+Version: 0.18.9
+Date: 2022-01-06
 Authors@R: c(person("Jan Philipp", "Dietrich", email = "dietrich@pik-potsdam.de", role = c("aut","cre")),
              person("David", "Klein", role = "aut"),
              person("Anastasis", "Giannousakis", role = "aut"),

--- a/R/extract_arguments.R
+++ b/R/extract_arguments.R
@@ -26,9 +26,10 @@
 
 # define function for extraction of indicies sets from command line input
 extract_arguments <- function(inputArg) {  # nolint
-  if (length(grep("=", inputArg) > 0)) inputArg <- strsplit(inputArg, "=")[[1]][2]
+  if (length(grep("=", inputArg) > 0)) inputArg <- sub(".*?=", "", inputArg) # everything after first =
+  if (inputArg == "") return("")
   if (length(grep(",", inputArg) > 0)) {
-    return(unlist(sapply(strsplit(inputArg, ",")[[1]], extract_arguments), use.names = FALSE))
+    return(unlist(sapply(strsplit(inputArg, ",")[[1]], extract_arguments), use.names = FALSE)) # nolint
   }
   if (length(strsplit(inputArg, ":")[[1]]) == 2) {
     if (suppressWarnings(is.na(as.integer(strsplit(inputArg, ":")[[1]][1])) |

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Code Manipulation and Analysis Tools
 
-R package **lucode2**, version **0.18.8**
+R package **lucode2**, version **0.18.9**
 
 [![CRAN status](https://www.r-pkg.org/badges/version/lucode2)](https://cran.r-project.org/package=lucode2) [![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.4389418.svg)](https://doi.org/10.5281/zenodo.4389418) [![R build status](https://github.com/pik-piam/lucode2/workflows/check/badge.svg)](https://github.com/pik-piam/lucode2/actions) [![codecov](https://codecov.io/gh/pik-piam/lucode2/branch/master/graph/badge.svg)](https://codecov.io/gh/pik-piam/lucode2) [![r-universe](https://pik-piam.r-universe.dev/badges/lucode2)](https://pik-piam.r-universe.dev/ui#builds)
 
@@ -38,7 +38,7 @@ In case of questions / problems please contact Jan Philipp Dietrich <dietrich@pi
 
 To cite package **lucode2** in publications use:
 
-Dietrich J, Klein D, Giannousakis A, Bonsch M, Bodirsky B, Baumstark L, Führlich P (2022). _lucode2: Code Manipulation and Analysis Tools_. doi: 10.5281/zenodo.4389418 (URL: https://doi.org/10.5281/zenodo.4389418), R package version 0.18.8, <URL: https://github.com/pik-piam/lucode2>.
+Dietrich J, Klein D, Giannousakis A, Bonsch M, Bodirsky B, Baumstark L, Führlich P (2022). _lucode2: Code Manipulation and Analysis Tools_. doi: 10.5281/zenodo.4389418 (URL: https://doi.org/10.5281/zenodo.4389418), R package version 0.18.9, <URL: https://github.com/pik-piam/lucode2>.
 
 A BibTeX entry for LaTeX users is
 
@@ -47,7 +47,7 @@ A BibTeX entry for LaTeX users is
   title = {lucode2: Code Manipulation and Analysis Tools},
   author = {Jan Philipp Dietrich and David Klein and Anastasis Giannousakis and Markus Bonsch and Benjamin Leon Bodirsky and Lavinia Baumstark and Pascal Führlich},
   year = {2022},
-  note = {R package version 0.18.8},
+  note = {R package version 0.18.9},
   doi = {10.5281/zenodo.4389418},
   url = {https://github.com/pik-piam/lucode2},
 }


### PR DESCRIPTION
this PR enables `extract_arguments()` to treat the allocation of empty strings and strings that contain a `=`, required for this issue in remind: https://github.com/remindmodel/remind/issues/315

`lucode2::buildLibrary()` told me that the (already existing) `sapply` is undesirable, but I think replacing it with `lapply` as suggested would change its behavior here.