### PR TITLE
add warnings to report

### DIFF
--- a/.buildlibrary
+++ b/.buildlibrary
@@ -1,4 +1,4 @@
-ValidationKey: '3609620'
+ValidationKey: '3628809'
 AutocreateReadme: yes
 AcceptedWarnings:
 - 'Warning: package ''.*'' was built under R version'

--- a/.zenodo.json
+++ b/.zenodo.json
@@ -1,6 +1,6 @@
 {
   "title": "lucode2: Code Manipulation and Analysis Tools",
-  "version": "0.19.0",
+  "version": "0.19.1",
   "description": "<p>A collection of tools which allow to manipulate and analyze code.<\/p>",
   "creators": [
     {

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Package: lucode2
 Type: Package
 Title: Code Manipulation and Analysis Tools
-Version: 0.19.0
-Date: 2022-01-06
+Version: 0.19.1
+Date: 2022-01-07
 Authors@R: c(person("Jan Philipp", "Dietrich", email = "dietrich@pik-potsdam.de", role = c("aut","cre")),
              person("David", "Klein", role = "aut"),
              person("Anastasis", "Giannousakis", role = "aut"),

--- a/R/checkup.R
+++ b/R/checkup.R
@@ -1,6 +1,6 @@
 #' checkup
 #'
-#' Checks the current R ecosystem for common problems and reports info such as OS and R version.
+#' Checks the current R setup for common problems and reports info such as OS and R version.
 #'
 #' @return Invisibly, the report as a list.
 #'
@@ -28,12 +28,12 @@ checkup <- function() {
 
   str(report)
 
-  message("Checking R ecosystem for problems... ", appendLF = FALSE)
+  message("Checking R setup for problems... ", appendLF = FALSE)
 
   report[["warnings"]] <- list()
 
   # Rscript uses the same version of R as this R session
-  rscriptVersion <- tail(system("Rscript -e 'cat(R.version.string)'", intern = TRUE), 1)
+  rscriptVersion <- tail(system("Rscript -e 'cat(R.version.string)'", intern = TRUE, ignore.stderr = TRUE), 1)
   if (rscriptVersion != R.version.string) {
     report[["warnings"]][["rscriptVersion"]] <- paste0("Rscript uses ", rscriptVersion, ", but this session uses ",
                                                        R.version.string)

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Code Manipulation and Analysis Tools
 
-R package **lucode2**, version **0.19.0**
+R package **lucode2**, version **0.19.1**
 
 [![CRAN status](https://www.r-pkg.org/badges/version/lucode2)](https://cran.r-project.org/package=lucode2) [![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.4389418.svg)](https://doi.org/10.5281/zenodo.4389418) [![R build status](https://github.com/pik-piam/lucode2/workflows/check/badge.svg)](https://github.com/pik-piam/lucode2/actions) [![codecov](https://codecov.io/gh/pik-piam/lucode2/branch/master/graph/badge.svg)](https://codecov.io/gh/pik-piam/lucode2) [![r-universe](https://pik-piam.r-universe.dev/badges/lucode2)](https://pik-piam.r-universe.dev/ui#builds)
 
@@ -38,7 +38,7 @@ In case of questions / problems please contact Jan Philipp Dietrich <dietrich@pi
 
 To cite package **lucode2** in publications use:
 
-Dietrich J, Klein D, Giannousakis A, Bonsch M, Bodirsky B, Baumstark L, Führlich P (2022). _lucode2: Code Manipulation and Analysis Tools_. doi: 10.5281/zenodo.4389418 (URL: https://doi.org/10.5281/zenodo.4389418), R package version 0.19.0, <URL: https://github.com/pik-piam/lucode2>.
+Dietrich J, Klein D, Giannousakis A, Bonsch M, Bodirsky B, Baumstark L, Führlich P (2022). _lucode2: Code Manipulation and Analysis Tools_. doi: 10.5281/zenodo.4389418 (URL: https://doi.org/10.5281/zenodo.4389418), R package version 0.19.1, <URL: https://github.com/pik-piam/lucode2>.
 
 A BibTeX entry for LaTeX users is
 
@@ -47,7 +47,7 @@ A BibTeX entry for LaTeX users is
   title = {lucode2: Code Manipulation and Analysis Tools},
   author = {Jan Philipp Dietrich and David Klein and Anastasis Giannousakis and Markus Bonsch and Benjamin Leon Bodirsky and Lavinia Baumstark and Pascal Führlich},
   year = {2022},
-  note = {R package version 0.19.0},
+  note = {R package version 0.19.1},
   doi = {10.5281/zenodo.4389418},
   url = {https://github.com/pik-piam/lucode2},
 }

--- a/man/checkup.Rd
+++ b/man/checkup.Rd
@@ -10,7 +10,7 @@ checkup()
 Invisibly, the report as a list.
 }
 \description{
-Checks the current R ecosystem for common problems and reports info such as OS and R version.
+Checks the current R setup for common problems and reports info such as OS and R version.
 }
 \author{
 Pascal Führlich


### PR DESCRIPTION
Add warnings to report so they can be searched and examined even if they too long to be displayed (truncated by default).