### PR TITLE
let eprint not print error message, but instead 'not found'

### DIFF
--- a/.buildlibrary
+++ b/.buildlibrary
@@ -1,4 +1,4 @@
-ValidationKey: '3628809'
+ValidationKey: '3648384'
 AutocreateReadme: yes
 AcceptedWarnings:
 - 'Warning: package ''.*'' was built under R version'

--- a/.zenodo.json
+++ b/.zenodo.json
@@ -1,6 +1,6 @@
 {
   "title": "lucode2: Code Manipulation and Analysis Tools",
-  "version": "0.19.1",
+  "version": "0.19.2",
   "description": "<p>A collection of tools which allow to manipulate and analyze code.<\/p>",
   "creators": [
     {

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Package: lucode2
 Type: Package
 Title: Code Manipulation and Analysis Tools
-Version: 0.19.1
-Date: 2022-01-07
+Version: 0.19.2
+Date: 2022-01-10
 Authors@R: c(person("Jan Philipp", "Dietrich", email = "dietrich@pik-potsdam.de", role = c("aut","cre")),
              person("David", "Klein", role = "aut"),
              person("Anastasis", "Giannousakis", role = "aut"),

--- a/R/eprint.R
+++ b/R/eprint.R
@@ -4,10 +4,10 @@
 #' to use for a log-file
 #'
 #'
-#' @param varName name of the variable that should be printed as string
+#' @param var_name name of the variable that should be printed as string
 #' @param envir environment from which the variable should be read (by default
 #' the environment from which the function is called)
-#' @author Jan Philipp Dietrich
+#' @author Jan Philipp Dietrich, Oliver Richters
 #' @seealso \code{\link{eprint_list}}
 #' @examples
 #' \dontrun{
@@ -18,11 +18,11 @@
 #' ### print additional information concerning loaded configuration###
 #' ### ePrint (extended Print) offers an extended output functionality which
 #' ### allows to create easily log-files with all relevant information
-eprint <- function(varName, envir = parent.frame()) {
-  varValue <- try(get(varName, envir = envir), silent = TRUE)
+eprint <- function(var_name, envir = parent.frame()) { # nolint
+  varValue <- try(get(var_name, envir = envir), silent = TRUE)
   if (class(varValue) == "try-error") {
-    cat(paste(varName, "not found\n"))
+    message(paste(var_name, "not found"))
   } else {
-    cat(paste(varName, "<-", varValue, "\n"))
+    message(paste(var_name, "<-", varValue))
   }
 }

--- a/R/eprint.R
+++ b/R/eprint.R
@@ -4,7 +4,7 @@
 #' to use for a log-file
 #'
 #'
-#' @param var_name name of the variable that should be printed as string
+#' @param varName name of the variable that should be printed as string
 #' @param envir environment from which the variable should be read (by default
 #' the environment from which the function is called)
 #' @author Jan Philipp Dietrich
@@ -18,6 +18,11 @@
 #' ### print additional information concerning loaded configuration###
 #' ### ePrint (extended Print) offers an extended output functionality which
 #' ### allows to create easily log-files with all relevant information
-eprint <- function(var_name, envir = parent.frame()) {
-  print(paste(var_name, "<-", try(get(var_name, envir = envir), silent = TRUE)), quote = FALSE)
+eprint <- function(varName, envir = parent.frame()) {
+  varValue <- try(get(varName, envir = envir), silent = TRUE)
+  if (class(varValue) == "try-error") {
+    cat(paste(varName, "not found\n"))
+  } else {
+    cat(paste(varName, "<-", varValue, "\n"))
+  }
 }

--- a/R/readArgs.R
+++ b/R/readArgs.R
@@ -53,8 +53,8 @@ readArgs <- function(..., .envir = parent.frame(), .silent = FALSE) {
     }
   }
   if (!.silent) {
-    cat("\n\n### READ COMMAND LINE - ASSIGNED CONFIGURATION ###\n")
+    message("\n### READ COMMAND LINE - ASSIGNED CONFIGURATION ###")
     eprint_list(allowedArgs, envir = .envir)
-    cat("### READ COMMAND LINE - CONFIGURATION END ###\n\n")
+    message("### READ COMMAND LINE - CONFIGURATION END ###\n")
   }
 }

--- a/R/readArgs.R
+++ b/R/readArgs.R
@@ -18,24 +18,25 @@
 #' value1 <- "old"
 #' value2 <- 2
 #' value3 <- "willstaythesame"
-#' readArgs("value1", "value2")
-#' print(value1)
-#' print(value2)
-#' print(value3)
+#' readArgs("value1", "value2", "value4")
+#' cat(value1, "\n")
+#' cat(value2, "\n")
+#' cat(value3, "\n")
 #'
 #' # Open the command line and execute the following code:
 #' # Rscript test.R value1=new value2=3 value3=isnotallowed
 #'
 #' # Output:
-#' # [1]
-#' # [1] ### READ COMMAND LINE - ASSIGNED CONFIGURATION ###
-#' # [1] value1 <- new
-#' # [1] value2 <- 3
-#' # [1] ### READ COMMAND LINE - CONFIGURATION END ###
-#' # [1]
-#' # [1] "new"
-#' # [1] 3
-#' # [1] "willstaythesame"
+#' #
+#' # ### READ COMMAND LINE - ASSIGNED CONFIGURATION ###
+#' # value1 <- new
+#' # value2 <- 3
+#' # value4 not found
+#' # ### READ COMMAND LINE - CONFIGURATION END ###
+#' #
+#' # "new"
+#' # 3
+#' # "willstaythesame"
 #'
 #'
 #' ### function that reads all allowed arguments from command line###
@@ -52,10 +53,8 @@ readArgs <- function(..., .envir = parent.frame(), .silent = FALSE) {
     }
   }
   if (!.silent) {
-    print("", quote = FALSE)
-    print("### READ COMMAND LINE - ASSIGNED CONFIGURATION ###", quote = FALSE)
+    cat("\n\n### READ COMMAND LINE - ASSIGNED CONFIGURATION ###\n")
     eprint_list(allowedArgs, envir = .envir)
-    print("### READ COMMAND LINE - CONFIGURATION END ###", quote = FALSE)
-    print("", quote = FALSE)
+    cat("### READ COMMAND LINE - CONFIGURATION END ###\n\n")
   }
 }

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Code Manipulation and Analysis Tools
 
-R package **lucode2**, version **0.19.1**
+R package **lucode2**, version **0.19.2**
 
 [![CRAN status](https://www.r-pkg.org/badges/version/lucode2)](https://cran.r-project.org/package=lucode2) [![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.4389418.svg)](https://doi.org/10.5281/zenodo.4389418) [![R build status](https://github.com/pik-piam/lucode2/workflows/check/badge.svg)](https://github.com/pik-piam/lucode2/actions) [![codecov](https://codecov.io/gh/pik-piam/lucode2/branch/master/graph/badge.svg)](https://codecov.io/gh/pik-piam/lucode2) [![r-universe](https://pik-piam.r-universe.dev/badges/lucode2)](https://pik-piam.r-universe.dev/ui#builds)
 
@@ -38,7 +38,7 @@ In case of questions / problems please contact Jan Philipp Dietrich <dietrich@pi
 
 To cite package **lucode2** in publications use:
 
-Dietrich J, Klein D, Giannousakis A, Bonsch M, Bodirsky B, Baumstark L, Führlich P (2022). _lucode2: Code Manipulation and Analysis Tools_. doi: 10.5281/zenodo.4389418 (URL: https://doi.org/10.5281/zenodo.4389418), R package version 0.19.1, <URL: https://github.com/pik-piam/lucode2>.
+Dietrich J, Klein D, Giannousakis A, Bonsch M, Bodirsky B, Baumstark L, Führlich P (2022). _lucode2: Code Manipulation and Analysis Tools_. doi: 10.5281/zenodo.4389418 (URL: https://doi.org/10.5281/zenodo.4389418), R package version 0.19.2, <URL: https://github.com/pik-piam/lucode2>.
 
 A BibTeX entry for LaTeX users is
 
@@ -47,7 +47,7 @@ A BibTeX entry for LaTeX users is
   title = {lucode2: Code Manipulation and Analysis Tools},
   author = {Jan Philipp Dietrich and David Klein and Anastasis Giannousakis and Markus Bonsch and Benjamin Leon Bodirsky and Lavinia Baumstark and Pascal Führlich},
   year = {2022},
-  note = {R package version 0.19.1},
+  note = {R package version 0.19.2},
   doi = {10.5281/zenodo.4389418},
   url = {https://github.com/pik-piam/lucode2},
 }

--- a/man/eprint.Rd
+++ b/man/eprint.Rd
@@ -4,10 +4,10 @@
 \alias{eprint}
 \title{extended Print}
 \usage{
-eprint(var_name, envir = parent.frame())
+eprint(varName, envir = parent.frame())
 }
 \arguments{
-\item{var_name}{name of the variable that should be printed as string}
+\item{varName}{name of the variable that should be printed as string}
 
 \item{envir}{environment from which the variable should be read (by default
 the environment from which the function is called)}

--- a/man/eprint.Rd
+++ b/man/eprint.Rd
@@ -4,10 +4,10 @@
 \alias{eprint}
 \title{extended Print}
 \usage{
-eprint(varName, envir = parent.frame())
+eprint(var_name, envir = parent.frame())
 }
 \arguments{
-\item{varName}{name of the variable that should be printed as string}
+\item{var_name}{name of the variable that should be printed as string}
 
 \item{envir}{environment from which the variable should be read (by default
 the environment from which the function is called)}
@@ -30,5 +30,5 @@ eprint("a")
 \code{\link{eprint_list}}
 }
 \author{
-Jan Philipp Dietrich
+Jan Philipp Dietrich, Oliver Richters
 }

--- a/man/readArgs.Rd
+++ b/man/readArgs.Rd
@@ -26,24 +26,25 @@ and transforms them to R-Values, if they are called as allowed arguments.
 value1 <- "old"
 value2 <- 2
 value3 <- "willstaythesame"
-readArgs("value1", "value2")
-print(value1)
-print(value2)
-print(value3)
+readArgs("value1", "value2", "value4")
+cat(value1, "\n")
+cat(value2, "\n")
+cat(value3, "\n")
 
 # Open the command line and execute the following code:
 # Rscript test.R value1=new value2=3 value3=isnotallowed
 
 # Output:
-# [1]
-# [1] ### READ COMMAND LINE - ASSIGNED CONFIGURATION ###
-# [1] value1 <- new
-# [1] value2 <- 3
-# [1] ### READ COMMAND LINE - CONFIGURATION END ###
-# [1]
-# [1] "new"
-# [1] 3
-# [1] "willstaythesame"
+#
+# ### READ COMMAND LINE - ASSIGNED CONFIGURATION ###
+# value1 <- new
+# value2 <- 3
+# value4 not found
+# ### READ COMMAND LINE - CONFIGURATION END ###
+#
+# "new"
+# 3
+# "willstaythesame"
 
 
 ### function that reads all allowed arguments from command line###


### PR DESCRIPTION
This fixes something that annoyed me working on [remind PR #621](https://github.com/remindmodel/remind/pull/621): If no command line arguments are provided, `readArgs.R` prints an error message despite using `try`, because apparently using `paste` on `try` concatenates this error message to the other strings.

I changed `eprint.R` such that it checks whether determining the variable value gives a `try-error` object, and if `TRUE`, states that the variable was not found. This also allows for a better distinction between “nothing was found and therefore the variable is not set” and “the variable was set to an empty string“, an ambiguity introduced by [my lucode2 PR #62](https://github.com/pik-piam/lucode2/pull/62).

I also switched from `print` to `cat` to avoid the `[1]` being printed, and changed `var_name` to `varName` because linter told me to.