### PR TITLE
bugfix in eprint, nice format if variable is a vector/list

### DIFF
--- a/.buildlibrary
+++ b/.buildlibrary
@@ -1,4 +1,4 @@
-ValidationKey: '3668737'
+ValidationKey: '3688328'
 AutocreateReadme: yes
 AcceptedWarnings:
 - 'Warning: package ''.*'' was built under R version'

--- a/.zenodo.json
+++ b/.zenodo.json
@@ -1,6 +1,6 @@
 {
   "title": "lucode2: Code Manipulation and Analysis Tools",
-  "version": "0.19.3",
+  "version": "0.19.4",
   "description": "<p>A collection of tools which allow to manipulate and analyze code.<\/p>",
   "creators": [
     {

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Package: lucode2
 Type: Package
 Title: Code Manipulation and Analysis Tools
-Version: 0.19.3
-Date: 2022-01-17
+Version: 0.19.4
+Date: 2022-01-20
 Authors@R: c(person("Jan Philipp", "Dietrich", email = "dietrich@pik-potsdam.de", role = c("aut","cre")),
              person("David", "Klein", role = "aut"),
              person("Anastasis", "Giannousakis", role = "aut"),

--- a/R/eprint.R
+++ b/R/eprint.R
@@ -23,6 +23,6 @@ eprint <- function(var_name, envir = parent.frame()) { # nolint
   if (class(varValue) == "try-error") {
     message(paste(var_name, "not found"))
   } else {
-    message(paste(var_name, "<-", varValue))
+    message(paste(var_name, "<-", paste(varValue, collapse = ", ")))
   }
 }

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Code Manipulation and Analysis Tools
 
-R package **lucode2**, version **0.19.3**
+R package **lucode2**, version **0.19.4**
 
 [![CRAN status](https://www.r-pkg.org/badges/version/lucode2)](https://cran.r-project.org/package=lucode2) [![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.4389418.svg)](https://doi.org/10.5281/zenodo.4389418) [![R build status](https://github.com/pik-piam/lucode2/workflows/check/badge.svg)](https://github.com/pik-piam/lucode2/actions) [![codecov](https://codecov.io/gh/pik-piam/lucode2/branch/master/graph/badge.svg)](https://codecov.io/gh/pik-piam/lucode2) [![r-universe](https://pik-piam.r-universe.dev/badges/lucode2)](https://pik-piam.r-universe.dev/ui#builds)
 
@@ -38,7 +38,7 @@ In case of questions / problems please contact Jan Philipp Dietrich <dietrich@pi
 
 To cite package **lucode2** in publications use:
 
-Dietrich J, Klein D, Giannousakis A, Bonsch M, Bodirsky B, Baumstark L, Führlich P (2022). _lucode2: Code Manipulation and Analysis Tools_. doi: 10.5281/zenodo.4389418 (URL: https://doi.org/10.5281/zenodo.4389418), R package version 0.19.3, <URL: https://github.com/pik-piam/lucode2>.
+Dietrich J, Klein D, Giannousakis A, Bonsch M, Bodirsky B, Baumstark L, Führlich P (2022). _lucode2: Code Manipulation and Analysis Tools_. doi: 10.5281/zenodo.4389418 (URL: https://doi.org/10.5281/zenodo.4389418), R package version 0.19.4, <URL: https://github.com/pik-piam/lucode2>.
 
 A BibTeX entry for LaTeX users is
 
@@ -47,7 +47,7 @@ A BibTeX entry for LaTeX users is
   title = {lucode2: Code Manipulation and Analysis Tools},
   author = {Jan Philipp Dietrich and David Klein and Anastasis Giannousakis and Markus Bonsch and Benjamin Leon Bodirsky and Lavinia Baumstark and Pascal Führlich},
   year = {2022},
-  note = {R package version 0.19.3},
+  note = {R package version 0.19.4},
   doi = {10.5281/zenodo.4389418},
   url = {https://github.com/pik-piam/lucode2},
 }


### PR DESCRIPTION
If an argument read with `readArgs("regionList")` from the command line is a vector, `eprint()` concatenates it in an unreadable way (example is from remind compareScenario logging):
```
### READ COMMAND LINE - ASSIGNED CONFIGURATION ###
regionList <- GLOregionList <- LAMregionList <- OASregionList <- SSAregionList <- EURregionList <- NEUregionList <- MEAregionList <- REFregionList <- CAZregionList <- CHAregionList <- INDregionList <- JPNregionList <- USA
### READ COMMAND LINE - CONFIGURATION END ###
```
This PR turns it into:
```
### READ COMMAND LINE - ASSIGNED CONFIGURATION ###
regionList <- GLO, LAM, OAS, SSA, EUR, NEU, MEA, REF, CAZ, CHA, IND, JPN, USA
### READ COMMAND LINE - CONFIGURATION END ###
```
Was probably caused by switching from `print` to `message` before.