### PR TITLE
Cache R packages in github actions

### DIFF
--- a/.buildlibrary
+++ b/.buildlibrary
@@ -1,4 +1,4 @@
-ValidationKey: '4596000'
+ValidationKey: '4788000'
 AutocreateReadme: yes
 AcceptedWarnings:
 - 'Warning: package ''.*'' was built under R version'

--- a/.github/workflows/lucode2-check.yaml
+++ b/.github/workflows/lucode2-check.yaml
@@ -69,6 +69,7 @@ jobs:
           sudo chmod 2777 /usr/local/lib/R /usr/local/lib/R/site-library
 
       - name: Update cached packages
+        run: |
           sudo Rscript -e 'update.packages()'
 
       - name: Install dependencies

--- a/.github/workflows/lucode2-check.yaml
+++ b/.github/workflows/lucode2-check.yaml
@@ -68,10 +68,6 @@ jobs:
         run: |
           sudo chmod 2777 /usr/local/lib/R /usr/local/lib/R/site-library
 
-      - name: Update cached packages
-        run: |
-          sudo Rscript -e 'update.packages()'
-
       - name: Install dependencies
         run: |
           ./run.sh install_aptget libhdf5-dev

--- a/.github/workflows/lucode2-check.yaml
+++ b/.github/workflows/lucode2-check.yaml
@@ -56,6 +56,21 @@ jobs:
 
       - uses: r-lib/actions/setup-pandoc@v1
 
+      - name: Cache R libraries
+        uses: actions/cache@v3
+        with:
+          path: /usr/local/lib/R/
+          key: ${{ runner.os }}-usr-local-lib-R-${{ hashFiles('DESCRIPTION') }}
+          restore-keys: |
+            ${{ runner.os }}-usr-local-lib-R-
+
+      - name: Restore R library permissions
+        run: |
+          sudo chmod 2777 /usr/local/lib/R /usr/local/lib/R/site-library
+
+      - name: Update cached packages
+          sudo Rscript -e 'update.packages()'
+
       - name: Install dependencies
         run: |
           ./run.sh install_aptget libhdf5-dev

--- a/.zenodo.json
+++ b/.zenodo.json
@@ -1,6 +1,6 @@
 {
   "title": "lucode2: Code Manipulation and Analysis Tools",
-  "version": "0.24.0",
+  "version": "0.25.0",
   "description": "<p>A collection of tools which allow to manipulate and analyze code.<\/p>",
   "creators": [
     {

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Package: lucode2
 Type: Package
 Title: Code Manipulation and Analysis Tools
-Version: 0.24.0
-Date: 2022-06-07
+Version: 0.25.0
+Date: 2022-06-09
 Authors@R: c(person("Jan Philipp", "Dietrich", email = "dietrich@pik-potsdam.de", role = c("aut","cre")),
              person("David", "Klein", role = "aut"),
              person("Anastasis", "Giannousakis", role = "aut"),

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Code Manipulation and Analysis Tools
 
-R package **lucode2**, version **0.24.0**
+R package **lucode2**, version **0.25.0**
 
 [![CRAN status](https://www.r-pkg.org/badges/version/lucode2)](https://cran.r-project.org/package=lucode2) [![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.4389418.svg)](https://doi.org/10.5281/zenodo.4389418) [![R build status](https://github.com/pik-piam/lucode2/workflows/check/badge.svg)](https://github.com/pik-piam/lucode2/actions) [![codecov](https://codecov.io/gh/pik-piam/lucode2/branch/master/graph/badge.svg)](https://app.codecov.io/gh/pik-piam/lucode2) [![r-universe](https://pik-piam.r-universe.dev/badges/lucode2)](https://pik-piam.r-universe.dev/ui#builds)
 
@@ -38,7 +38,7 @@ In case of questions / problems please contact Jan Philipp Dietrich <dietrich@pi
 
 To cite package **lucode2** in publications use:
 
-Dietrich J, Klein D, Giannousakis A, Bonsch M, Bodirsky B, Baumstark L, Führlich P (2022). _lucode2: Code Manipulation and Analysis Tools_. doi: 10.5281/zenodo.4389418 (URL: https://doi.org/10.5281/zenodo.4389418), R package version 0.24.0, <URL: https://github.com/pik-piam/lucode2>.
+Dietrich J, Klein D, Giannousakis A, Bonsch M, Bodirsky B, Baumstark L, Führlich P (2022). _lucode2: Code Manipulation and Analysis Tools_. doi:10.5281/zenodo.4389418 <https://doi.org/10.5281/zenodo.4389418>, R package version 0.25.0, <https://github.com/pik-piam/lucode2>.
 
 A BibTeX entry for LaTeX users is
 
@@ -47,7 +47,7 @@ A BibTeX entry for LaTeX users is
   title = {lucode2: Code Manipulation and Analysis Tools},
   author = {Jan Philipp Dietrich and David Klein and Anastasis Giannousakis and Markus Bonsch and Benjamin Leon Bodirsky and Lavinia Baumstark and Pascal Führlich},
   year = {2022},
-  note = {R package version 0.24.0},
+  note = {R package version 0.25.0},
   doi = {10.5281/zenodo.4389418},
   url = {https://github.com/pik-piam/lucode2},
 }

--- a/inst/extdata/lucode2-check.yaml
+++ b/inst/extdata/lucode2-check.yaml
@@ -69,6 +69,7 @@ jobs:
           sudo chmod 2777 /usr/local/lib/R /usr/local/lib/R/site-library
 
       - name: Update cached packages
+        run: |
           sudo Rscript -e 'update.packages()'
 
       - name: Install dependencies

--- a/inst/extdata/lucode2-check.yaml
+++ b/inst/extdata/lucode2-check.yaml
@@ -68,10 +68,6 @@ jobs:
         run: |
           sudo chmod 2777 /usr/local/lib/R /usr/local/lib/R/site-library
 
-      - name: Update cached packages
-        run: |
-          sudo Rscript -e 'update.packages()'
-
       - name: Install dependencies
         run: |
           ./run.sh install_aptget libhdf5-dev

--- a/inst/extdata/lucode2-check.yaml
+++ b/inst/extdata/lucode2-check.yaml
@@ -56,6 +56,21 @@ jobs:
 
       - uses: r-lib/actions/setup-pandoc@v1
 
+      - name: Cache R libraries
+        uses: actions/cache@v3
+        with:
+          path: /usr/local/lib/R/
+          key: ${{ runner.os }}-usr-local-lib-R-${{ hashFiles('DESCRIPTION') }}
+          restore-keys: |
+            ${{ runner.os }}-usr-local-lib-R-
+
+      - name: Restore R library permissions
+        run: |
+          sudo chmod 2777 /usr/local/lib/R /usr/local/lib/R/site-library
+
+      - name: Update cached packages
+          sudo Rscript -e 'update.packages()'
+
       - name: Install dependencies
         run: |
           ./run.sh install_aptget libhdf5-dev


### PR DESCRIPTION
Add a cache action which caches `/usr/local/lib/R` to github actions. In my [tests](https://github.com/pik-piam/gms/pull/24) it was significantly faster with a hot cache:

Without caching: 8m 34s
With caching (and hot cache): 3m 37s

Let's see how it does here.
