### PR TITLE
ask more than once for correct update type

### DIFF
--- a/.buildlibrary
+++ b/.buildlibrary
@@ -1,4 +1,4 @@
-ValidationKey: '5174820'
+ValidationKey: '5195341'
 AutocreateReadme: yes
 AcceptedWarnings:
 - 'Warning: package ''.*'' was built under R version'

--- a/.zenodo.json
+++ b/.zenodo.json
@@ -1,6 +1,6 @@
 {
   "title": "lucode2: Code Manipulation and Analysis Tools",
-  "version": "0.27.0",
+  "version": "0.27.1",
   "description": "<p>A collection of tools which allow to manipulate and analyze code.<\/p>",
   "creators": [
     {

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Package: lucode2
 Type: Package
 Title: Code Manipulation and Analysis Tools
-Version: 0.27.0
-Date: 2022-06-23
+Version: 0.27.1
+Date: 2022-06-28
 Authors@R: c(person("Jan Philipp", "Dietrich", email = "dietrich@pik-potsdam.de", role = c("aut","cre")),
              person("David", "Klein", role = "aut"),
              person("Anastasis", "Giannousakis", role = "aut"),

--- a/R/buildLibrary.R
+++ b/R/buildLibrary.R
@@ -181,19 +181,16 @@ buildLibrary <- function(lib = ".", cran = TRUE, updateType = NULL, # nolint
       "only for packages in development stage",
       "no version increment (only to use if version is already incremented!)"
     )
-    cat(title, ":\n")
+    cat(title, ":\n", sep = "")
     updateTypeNumber <- c(1:(length(updateType) - 1), 0)
     cat(paste(updateTypeNumber, updateType, sep = ": "), sep = "\n")
     cat("\nNumber: ")
     identifier <- getLine()
-    identifier <- as.numeric(strsplit(identifier, ",")[[1]])
-    if (any(!(identifier %in% updateTypeNumber))) {
-      stop(
-        "This choice (", identifier, ") is not possible. ",
-        "Please type in a number between 0 and ", length(updateType) - 1
-      )
+    if (any(!(as.numeric(identifier) %in% updateTypeNumber))) {
+      message("This choice (", identifier, ") is not possible.")
+      identifier <- chooseModule(title = paste0("Please type in a number between 0 and ", length(updateType) - 1))
     }
-    return(identifier)
+    return(as.numeric(identifier))
   }
 
   if (is.null(updateType)) {

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Code Manipulation and Analysis Tools
 
-R package **lucode2**, version **0.27.0**
+R package **lucode2**, version **0.27.1**
 
 [![CRAN status](https://www.r-pkg.org/badges/version/lucode2)](https://cran.r-project.org/package=lucode2) [![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.4389418.svg)](https://doi.org/10.5281/zenodo.4389418) [![R build status](https://github.com/pik-piam/lucode2/workflows/check/badge.svg)](https://github.com/pik-piam/lucode2/actions) [![codecov](https://codecov.io/gh/pik-piam/lucode2/branch/master/graph/badge.svg)](https://app.codecov.io/gh/pik-piam/lucode2) [![r-universe](https://pik-piam.r-universe.dev/badges/lucode2)](https://pik-piam.r-universe.dev/ui#builds)
 
@@ -38,7 +38,7 @@ In case of questions / problems please contact Jan Philipp Dietrich <dietrich@pi
 
 To cite package **lucode2** in publications use:
 
-Dietrich J, Klein D, Giannousakis A, Bonsch M, Bodirsky B, Baumstark L, Führlich P (2022). _lucode2: Code Manipulation and Analysis Tools_. doi:10.5281/zenodo.4389418 <https://doi.org/10.5281/zenodo.4389418>, R package version 0.27.0, <https://github.com/pik-piam/lucode2>.
+Dietrich J, Klein D, Giannousakis A, Bonsch M, Bodirsky B, Baumstark L, Führlich P (2022). _lucode2: Code Manipulation and Analysis Tools_. doi: 10.5281/zenodo.4389418 (URL: https://doi.org/10.5281/zenodo.4389418), R package version 0.27.1, <URL: https://github.com/pik-piam/lucode2>.
 
 A BibTeX entry for LaTeX users is
 
@@ -47,7 +47,7 @@ A BibTeX entry for LaTeX users is
   title = {lucode2: Code Manipulation and Analysis Tools},
   author = {Jan Philipp Dietrich and David Klein and Anastasis Giannousakis and Markus Bonsch and Benjamin Leon Bodirsky and Lavinia Baumstark and Pascal Führlich},
   year = {2022},
-  note = {R package version 0.27.0},
+  note = {R package version 0.27.1},
   doi = {10.5281/zenodo.4389418},
   url = {https://github.com/pik-piam/lucode2},
 }


### PR DESCRIPTION
At the end of buildLibrary(), the script asks for an update type. In case of a [fat-finger problem](https://en.wikipedia.org/wiki/Fat-finger_error) where a wrong value is entered, it breaks everything. As the whole buildLibrary() process can take some time, this PR enables that if entered value makes no sense, it simply asks again, giving you an infinite number of chances…

I also took out the `strsplit(identifier, ",")` part, as it makes no sense to allow multiple answers such as `1,2` here…