### PR TITLE
DESCRIPTION metadata & precommit hooks

### DIFF
--- a/.buildlibrary
+++ b/.buildlibrary
@@ -1,4 +1,4 @@
-ValidationKey: '5374040'
+ValidationKey: '5374320'
 AutocreateReadme: yes
 AcceptedWarnings:
 - 'Warning: package ''.*'' was built under R version'

--- a/.buildlibrary
+++ b/.buildlibrary
@@ -1,4 +1,4 @@
-ValidationKey: '5257238'
+ValidationKey: '5374040'
 AutocreateReadme: yes
 AcceptedWarnings:
 - 'Warning: package ''.*'' was built under R version'

--- a/.github/workflows/lucode2-check.yaml
+++ b/.github/workflows/lucode2-check.yaml
@@ -70,7 +70,7 @@ jobs:
 
       - name: Install dependencies
         run: |
-          ./run.sh install_aptget libhdf5-dev
+          ./run.sh install_aptget libhdf5-dev libharfbuzz-dev libfribidi-dev
           ./run.sh install_all
           ./run.sh install_r lucode2 covr rstudioapi
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -19,9 +19,11 @@ repos:
     hooks:
     -   id: parsable-R
     -   id: deps-in-desc
+        args: [--allow_private_imports]
     -   id: no-browser-statement
     -   id: no-debug-statement
     -   id: readme-rmd-rendered
+    -   id: use-tidy-description
     -   id: roxygenize
         additional_dependencies:
         - citation

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -24,13 +24,5 @@ repos:
     -   id: no-debug-statement
     -   id: readme-rmd-rendered
     -   id: use-tidy-description
-    -   id: roxygenize
-        additional_dependencies:
-        - citation
-        - data.table
-        - devtools
-        - dplyr
-        - usethis
-        - git2r
 ci:
     autoupdate_schedule: weekly

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -7,8 +7,18 @@ repos:
     hooks:
     -   id: check-case-conflict
     -   id: check-json
-    -   id: check-yaml
     -   id: check-merge-conflict
+    -   id: check-yaml
     -   id: fix-byte-order-marker
+-   repo: https://github.com/lorenzwalthert/precommit
+    rev: v0.3.2
+    hooks:
+    -   id: deps-in-desc
+    -   id: no-browser-statement
+    -   id: no-debug-statement
+    -   id: parsable-R
+    -   id: readme-rmd-rendered
+    -   id: roxygenize
+    -   id: use-tidy-description
 ci:
     autoupdate_schedule: weekly

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -13,7 +13,6 @@ repos:
     -   id: check-added-large-files
         args: ['--maxkb=100']
     -   id: mixed-line-ending
-        args: ['--fix=lf']
 
 -   repo: https://github.com/lorenzwalthert/precommit
     rev: v0.3.2

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -10,15 +10,26 @@ repos:
     -   id: check-merge-conflict
     -   id: check-yaml
     -   id: fix-byte-order-marker
+    -   id: check-added-large-files
+        args: ['--maxkb=100']
+    -   id: mixed-line-ending
+        args: ['--fix=lf']
+
 -   repo: https://github.com/lorenzwalthert/precommit
     rev: v0.3.2
     hooks:
+    -   id: parsable-R
     -   id: deps-in-desc
     -   id: no-browser-statement
     -   id: no-debug-statement
-    -   id: parsable-R
     -   id: readme-rmd-rendered
     -   id: roxygenize
-    -   id: use-tidy-description
+        additional_dependencies:
+        - citation
+        - data.table
+        - devtools
+        - dplyr
+        - usethis
+        - git2r
 ci:
     autoupdate_schedule: weekly

--- a/.zenodo.json
+++ b/.zenodo.json
@@ -1,6 +1,6 @@
 {
   "title": "lucode2: Code Manipulation and Analysis Tools",
-  "version": "0.27.4",
+  "version": "0.28.0",
   "description": "<p>A collection of tools which allow to manipulate and analyze code.<\/p>",
   "creators": [
     {

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -35,8 +35,8 @@ Suggests:
     lusweave,
     magclass,
     poorman,
-    rmarkdown,
     renv,
+    rmarkdown,
     testthat
 URL: https://github.com/pik-piam/lucode2, https://doi.org/10.5281/zenodo.4389418
 BugReports: https://github.com/pik-piam/lucode2/issues

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Package: lucode2
 Type: Package
 Title: Code Manipulation and Analysis Tools
-Version: 0.27.4
-Date: 2022-07-14
+Version: 0.28.0
+Date: 2022-07-20
 Authors@R: c(person("Jan Philipp", "Dietrich", email = "dietrich@pik-potsdam.de", role = c("aut","cre")),
              person("David", "Klein", role = "aut"),
              person("Anastasis", "Giannousakis", role = "aut"),

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -35,8 +35,8 @@ Suggests:
     lusweave,
     magclass,
     poorman,
-    renv,
     rmarkdown,
+    renv,
     testthat
 URL: https://github.com/pik-piam/lucode2, https://doi.org/10.5281/zenodo.4389418
 BugReports: https://github.com/pik-piam/lucode2/issues

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -2,7 +2,7 @@ Package: lucode2
 Type: Package
 Title: Code Manipulation and Analysis Tools
 Version: 0.28.0
-Date: 2022-07-20
+Date: 2022-07-21
 Authors@R: c(person("Jan Philipp", "Dietrich", email = "dietrich@pik-potsdam.de", role = c("aut","cre")),
              person("David", "Klein", role = "aut"),
              person("Anastasis", "Giannousakis", role = "aut"),
@@ -43,4 +43,4 @@ BugReports: https://github.com/pik-piam/lucode2/issues
 License: BSD_2_clause + file LICENSE
 LazyData: no
 Encoding: UTF-8
-RoxygenNote: 7.2.0
+RoxygenNote: 7.2.1

--- a/R/check.R
+++ b/R/check.R
@@ -32,7 +32,7 @@ check <- function(lib = ".", cran = TRUE, config = loadBuildLibraryConfig(lib), 
 
   packageName <- desc("DESCRIPTION")$get("Package")
   packageDocumentation <- file.path("R", paste0(packageName, "-package.R"))
-  if (!file.exists(packageDocumentation)) {
+  if (!file.exists(packageDocumentation) && !file.exists(file.path("R", paste0(packageName, ".R")))) {
     writeLines(c("# The package documentation is defined in this file.",
                  "# You can get it via `library(<package>); ?<package>`.",
                  "#' @docType package",

--- a/R/check.R
+++ b/R/check.R
@@ -67,24 +67,6 @@ check <- function(lib = ".", cran = TRUE, config = loadBuildLibraryConfig(lib), 
 
   ########### Run linter ###########
   if (runLinter) {
-    # create .lintr config files if they do not exist
-    writeIfNonExistent <- function(fileText, filePath) {
-      if (!file.exists(filePath)) {
-        writeLines(fileText, filePath)
-      }
-      if (!paste0("^", filePath, "$") %in% readLines(".Rbuildignore")) {
-        write(paste0("^", filePath, "$"), ".Rbuildignore", append = TRUE)
-      }
-    }
-    writeIfNonExistent(c("linters: lucode2::lintrRules()", 'encoding: "UTF-8"'),
-                       ".lintr")
-    writeIfNonExistent(c("linters: lucode2::lintrRules(allowUndesirable = TRUE)", 'encoding: "UTF-8"'),
-                       file.path("tests", ".lintr", fsep = "/"))
-    if (dir.exists("vignettes")) {
-      writeIfNonExistent(c("linters: lucode2::lintrRules(allowUndesirable = TRUE)", 'encoding: "UTF-8"'),
-                         file.path("vignettes", ".lintr", fsep = "/"))
-    }
-
     # run linter and check results
     linterResult <- lint()
     print(linterResult)

--- a/R/lucode2-package.R
+++ b/R/lucode2-package.R
@@ -1,4 +1,4 @@
 # The package documentation is defined in this file.
-# You can get it via `library(<package>); ?<package>`
+# You can get it via `library(<package>); ?<package>`.
 #' @docType package
 "_PACKAGE"

--- a/R/packageInfo.R
+++ b/R/packageInfo.R
@@ -11,7 +11,9 @@
 #' @export
 #' @examples
 #' packageInfo("lucode2")
-packageInfo <- function(package, repos = c("https://cran.rstudio.com/", "https://rse.pik-potsdam.de/r/packages/")) {
+packageInfo <- function(package, repos = c("https://cran.rstudio.com/",
+                                           "https://rse.pik-potsdam.de/r/packages/",
+                                           "https://pik-piam.r-universe.dev")) {
   version <- try(packageVersion(package), silent = TRUE)
   if ("try-error" %in% class(version)) {
     version <- "<not installed>"

--- a/R/packageInfo.R
+++ b/R/packageInfo.R
@@ -34,7 +34,7 @@ packageInfo <- function(package, repos = c("https://cran.rstudio.com/",
     v <- list()
     for (r in repos) {
       v$r <- tryCatch(
-        available.packages(paste0(r, "/src/contrib"))[package, "Version"],
+        available.packages(file.path(r, "src", "contrib"))[package, "Version"],
         error = function(e) return("<not available>"))
       cat(v$r, "|", r, "\n")
     }

--- a/R/packageInfo.R
+++ b/R/packageInfo.R
@@ -1,7 +1,7 @@
 #' packageInfo
 #'
-#' Function to print version number and time since last update
-#' formatted to the standard output
+#' Function to print version number and time since last update formatted to standard output.
+#' Considers CRAN, the RSE server, and r-universe.
 #'
 #' @param package Package name
 #' @param repos vector of package repositories in which availability of the package should

--- a/R/updateRepo.R
+++ b/R/updateRepo.R
@@ -69,6 +69,7 @@ updateRepo <- function(path = ".", check = TRUE, forceRebuild = FALSE, clean = F
             error <- try(devtools::document(pkg = ".", roclets = c("rd", "collate", "namespace", "vignette")))
           }
           if (!("try-error" %in% class(error))) {
+            # add metadata such as remote url to DESCRIPTION e.g. for renv
             remoteUrl <- gert::git_remote_info()$url
             if (startsWith("git@github.com:", remoteUrl)) {
               remoteUrl <- sub("^git@github\\.com:", "https://github.com/", remoteUrl)

--- a/R/updateRepo.R
+++ b/R/updateRepo.R
@@ -75,13 +75,15 @@ updateRepo <- function(path = ".", check = TRUE, forceRebuild = FALSE, clean = F
               remoteUrl <- sub("\\.git$", "", remoteUrl)
             }
 
-            writeLines(paste0("Repository: ", repoUrl, "\n",
-                              "RemoteUrl: ", remoteUrl, "\n",
-                              "RemoteRef: HEAD\n",
-                              "RemoteSha: ", gert::git_commit_id(), "\n"),
-                       withr::local_connection(file("DESCRIPTION", "a"))) # open DESCRIPTION in append mode
+            cat("Repository: ", repoUrl, "\n",
+                "RemoteUrl: ", remoteUrl, "\n",
+                "RemoteRef: HEAD\n",
+                "RemoteSha: ", gert::git_commit_id(), "\n",
+                file = "DESCRIPTION", sep = "", append = TRUE)
+
             error <- try(devtools::build())
-            gert::git_reset_hard()
+
+            gert::git_reset_hard() # reset DESCRIPTION changes to prevent merge conflict
           }
           if ("try-error" %in% class(error)) {
             message(".:: ", fd, " ", curversion, " -> ", vkey$version, " build failed ::.")

--- a/R/updateRepo.R
+++ b/R/updateRepo.R
@@ -10,6 +10,7 @@
 #' @param forceRebuild Option to rebuild all packages from source
 #' @param clean Option to clean repos before updating/pulling to avoid merge conflicts
 #' @param skipFolders Which folders/packages should not be built.
+#' @param repoUrl Url of the package repo. Will be added to DESCRIPTION files in the Repository field.
 #' @author Jan Philipp Dietrich, Pascal Führlich
 #' @seealso \code{\link{buildLibrary}}
 #' @importFrom devtools document build install_deps
@@ -17,7 +18,9 @@
 #' @importFrom withr local_dir local_envvar with_dir
 #' @export
 updateRepo <- function(path = ".", check = TRUE, forceRebuild = FALSE, clean = FALSE, # nolint
-                       skipFolders = c("Archive", "gdxrrw", "HARr")) {
+                       skipFolders = c("Archive", "gdxrrw", "HARr"),
+                       repoUrl = "https://rse.pik-potsdam.de/r/packages") {
+  checkRequiredPackages("gert", "get git remote url and commit hash")
   path <- normalizePath(path)
   local_dir(path)
   message(date(), "\n")
@@ -66,7 +69,19 @@ updateRepo <- function(path = ".", check = TRUE, forceRebuild = FALSE, clean = F
             error <- try(devtools::document(pkg = ".", roclets = c("rd", "collate", "namespace", "vignette")))
           }
           if (!("try-error" %in% class(error))) {
+            remoteUrl <- gert::git_remote_info()$url
+            if (startsWith("git@github.com:", remoteUrl)) {
+              remoteUrl <- sub("^git@github\\.com:", "https://github.com/", remoteUrl)
+              remoteUrl <- sub("\\.git$", "", remoteUrl)
+            }
+
+            writeLines(paste0("Repository: ", repoUrl, "\n",
+                              "RemoteUrl: ", remoteUrl, "\n",
+                              "RemoteRef: HEAD\n",
+                              "RemoteSha: ", gert::git_commit_id(), "\n"),
+                       withr::local_connection(file("DESCRIPTION", "a"))) # open DESCRIPTION in append mode
             error <- try(devtools::build())
+            gert::git_reset_hard()
           }
           if ("try-error" %in% class(error)) {
             message(".:: ", fd, " ", curversion, " -> ", vkey$version, " build failed ::.")

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Code Manipulation and Analysis Tools
 
-R package **lucode2**, version **0.27.4**
+R package **lucode2**, version **0.28.0**
 
 [![CRAN status](https://www.r-pkg.org/badges/version/lucode2)](https://cran.r-project.org/package=lucode2) [![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.4389418.svg)](https://doi.org/10.5281/zenodo.4389418) [![R build status](https://github.com/pik-piam/lucode2/workflows/check/badge.svg)](https://github.com/pik-piam/lucode2/actions) [![codecov](https://codecov.io/gh/pik-piam/lucode2/branch/master/graph/badge.svg)](https://app.codecov.io/gh/pik-piam/lucode2) [![r-universe](https://pik-piam.r-universe.dev/badges/lucode2)](https://pik-piam.r-universe.dev/ui#builds)
 
@@ -38,7 +38,7 @@ In case of questions / problems please contact Jan Philipp Dietrich <dietrich@pi
 
 To cite package **lucode2** in publications use:
 
-Dietrich J, Klein D, Giannousakis A, Bonsch M, Bodirsky B, Baumstark L, Führlich P (2022). _lucode2: Code Manipulation and Analysis Tools_. doi:10.5281/zenodo.4389418 <https://doi.org/10.5281/zenodo.4389418>, R package version 0.27.4, <https://github.com/pik-piam/lucode2>.
+Dietrich J, Klein D, Giannousakis A, Bonsch M, Bodirsky B, Baumstark L, Führlich P (2022). _lucode2: Code Manipulation and Analysis Tools_. doi:10.5281/zenodo.4389418 <https://doi.org/10.5281/zenodo.4389418>, R package version 0.28.0, <https://github.com/pik-piam/lucode2>.
 
 A BibTeX entry for LaTeX users is
 
@@ -47,7 +47,7 @@ A BibTeX entry for LaTeX users is
   title = {lucode2: Code Manipulation and Analysis Tools},
   author = {Jan Philipp Dietrich and David Klein and Anastasis Giannousakis and Markus Bonsch and Benjamin Leon Bodirsky and Lavinia Baumstark and Pascal Führlich},
   year = {2022},
-  note = {R package version 0.27.4},
+  note = {R package version 0.28.0},
   doi = {10.5281/zenodo.4389418},
   url = {https://github.com/pik-piam/lucode2},
 }

--- a/inst/extdata/lucode2-check.yaml
+++ b/inst/extdata/lucode2-check.yaml
@@ -70,7 +70,7 @@ jobs:
 
       - name: Install dependencies
         run: |
-          ./run.sh install_aptget libhdf5-dev
+          ./run.sh install_aptget libhdf5-dev libharfbuzz-dev libfribidi-dev
           ./run.sh install_all
           ./run.sh install_r lucode2 covr rstudioapi
 

--- a/inst/extdata/pre-commit-config.yaml
+++ b/inst/extdata/pre-commit-config.yaml
@@ -7,8 +7,28 @@ repos:
     hooks:
     -   id: check-case-conflict
     -   id: check-json
-    -   id: check-yaml
     -   id: check-merge-conflict
+    -   id: check-yaml
     -   id: fix-byte-order-marker
+    -   id: check-added-large-files
+        args: ['--maxkb=100']
+    -   id: mixed-line-ending
+
+-   repo: https://github.com/lorenzwalthert/precommit
+    rev: v0.3.2
+    hooks:
+    -   id: parsable-R
+    -   id: deps-in-desc
+    -   id: no-browser-statement
+    -   id: no-debug-statement
+    -   id: readme-rmd-rendered
+    -   id: roxygenize
+        additional_dependencies:
+        - citation
+        - data.table
+        - devtools
+        - dplyr
+        - usethis
+        - git2r
 ci:
     autoupdate_schedule: weekly

--- a/inst/extdata/pre-commit-config.yaml
+++ b/inst/extdata/pre-commit-config.yaml
@@ -19,9 +19,11 @@ repos:
     hooks:
     -   id: parsable-R
     -   id: deps-in-desc
+        args: [--allow_private_imports]
     -   id: no-browser-statement
     -   id: no-debug-statement
     -   id: readme-rmd-rendered
+    -   id: use-tidy-description
     -   id: roxygenize
         additional_dependencies:
         - citation

--- a/inst/extdata/pre-commit-config.yaml
+++ b/inst/extdata/pre-commit-config.yaml
@@ -24,13 +24,5 @@ repos:
     -   id: no-debug-statement
     -   id: readme-rmd-rendered
     -   id: use-tidy-description
-    -   id: roxygenize
-        additional_dependencies:
-        - citation
-        - data.table
-        - devtools
-        - dplyr
-        - usethis
-        - git2r
 ci:
     autoupdate_schedule: weekly

--- a/man/packageInfo.Rd
+++ b/man/packageInfo.Rd
@@ -6,7 +6,8 @@
 \usage{
 packageInfo(
   package,
-  repos = c("https://cran.rstudio.com/", "https://rse.pik-potsdam.de/r/packages/")
+  repos = c("https://cran.rstudio.com/", "https://rse.pik-potsdam.de/r/packages/",
+    "https://pik-piam.r-universe.dev")
 )
 }
 \arguments{
@@ -16,8 +17,8 @@ packageInfo(
 be checked}
 }
 \description{
-Function to print version number and time since last update
-formatted to the standard output
+Function to print version number and time since last update formatted to standard output.
+Considers CRAN, the RSE server, and r-universe.
 }
 \examples{
 packageInfo("lucode2")

--- a/man/updateRepo.Rd
+++ b/man/updateRepo.Rd
@@ -9,7 +9,8 @@ updateRepo(
   check = TRUE,
   forceRebuild = FALSE,
   clean = FALSE,
-  skipFolders = c("Archive", "gdxrrw", "HARr")
+  skipFolders = c("Archive", "gdxrrw", "HARr"),
+  repoUrl = "https://rse.pik-potsdam.de/r/packages"
 )
 }
 \arguments{
@@ -22,6 +23,8 @@ updateRepo(
 \item{clean}{Option to clean repos before updating/pulling to avoid merge conflicts}
 
 \item{skipFolders}{Which folders/packages should not be built.}
+
+\item{repoUrl}{Url of the package repo. Will be added to DESCRIPTION files in the Repository field.}
 }
 \description{
 Function to update an package repository. Run this function on a folder which contains


### PR DESCRIPTION
`lucode2::updateRepo` now writes more metadata (just like r-universe) to DESCRIPTION files which is consumed e.g. by renv. Also added the following pre-commit hooks:
-   id: parsable-R
-   id: deps-in-desc
-   id: no-browser-statement
-   id: no-debug-statement
-   id: readme-rmd-rendered
-   id: use-tidy-description (which is not working at the moment, but will hopefully be fixed soon)
-   id: check-added-large-files
    args: ['--maxkb=100']
-   id: mixed-line-ending

`devtools` >= 2.4.4 requires additional system dependencies, they were added to the GitHub Action.