### PR TITLE
rewrite updateRepo to collect and throw errors

### DIFF
--- a/.buildlibrary
+++ b/.buildlibrary
@@ -1,4 +1,4 @@
-ValidationKey: '5633804'
+ValidationKey: '5658912'
 AutocreateReadme: yes
 AcceptedWarnings:
 - 'Warning: package ''.*'' was built under R version'

--- a/.github/workflows/lucode2-check.yaml
+++ b/.github/workflows/lucode2-check.yaml
@@ -77,7 +77,7 @@ jobs:
         run: |
           ./run.sh install_aptget libhdf5-dev libharfbuzz-dev libfribidi-dev
           ./run.sh install_all
-          ./run.sh install_r lucode2 covr rstudioapi
+          ./run.sh install_r lucode2 covr rstudioapi roxygen2
 
       - name: Install python dependencies if applicable
         run: |

--- a/.github/workflows/lucode2-check.yaml
+++ b/.github/workflows/lucode2-check.yaml
@@ -11,7 +11,7 @@ on:
 env:
   USE_BSPM: "true"
   _R_CHECK_FORCE_SUGGESTS_: "false"
-  NO_BINARY_INSTALL_R_PACKAGES: 'c("madrat", "magclass", "citation", "gms", "goxygen", "GDPuc")'
+  NO_BINARY_INSTALL_R_PACKAGES: 'c("madrat", "magclass", "citation", "gms", "goxygen", "GDPuc", "roxygen2")'
 
 jobs:
   lucode2-check:
@@ -77,7 +77,7 @@ jobs:
         run: |
           ./run.sh install_aptget libhdf5-dev libharfbuzz-dev libfribidi-dev
           ./run.sh install_all
-          ./run.sh install_r lucode2 covr rstudioapi roxygen2
+          ./run.sh install_r lucode2 covr rstudioapi
 
       - name: Install python dependencies if applicable
         run: |

--- a/.zenodo.json
+++ b/.zenodo.json
@@ -1,6 +1,6 @@
 {
   "title": "lucode2: Code Manipulation and Analysis Tools",
-  "version": "0.29.3",
+  "version": "0.29.4",
   "description": "<p>A collection of tools which allow to manipulate and analyze code.<\/p>",
   "creators": [
     {

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Package: lucode2
 Type: Package
 Title: Code Manipulation and Analysis Tools
-Version: 0.29.3
-Date: 2022-08-24
+Version: 0.29.4
+Date: 2022-09-13
 Authors@R: c(person("Jan Philipp", "Dietrich", email = "dietrich@pik-potsdam.de", role = c("aut","cre")),
              person("David", "Klein", role = "aut"),
              person("Anastasis", "Giannousakis", role = "aut"),

--- a/R/check.R
+++ b/R/check.R
@@ -45,8 +45,8 @@ check <- function(lib = ".", cran = TRUE, config = loadBuildLibraryConfig(lib), 
   # run tests in a separate R session so test results are independent of anything set in the current R session
   testResults <- callr::r(function() {
     withr::local_options(crayon.enabled = TRUE)
-    return(devtools::test(stop_on_failure = TRUE))
-  }, show = TRUE)
+    return(devtools::test(stop_on_failure = TRUE, reporter = "summary"))
+  }, show = TRUE, spinner = FALSE)
 
   helpLink <- "You can find solutions to common problems at https://github.com/pik-piam/discussions/discussions/18"
   unacceptedWarnings <- testResults %>%

--- a/R/conditionalCopy.R
+++ b/R/conditionalCopy.R
@@ -20,7 +20,8 @@ conditionalCopy <- function(relativePath, nameInInstExtdata = basename(relativeP
   dir.create(dirname(relativePath), recursive = TRUE, showWarnings = FALSE)
   if (desc("DESCRIPTION")$get("Package") == "lucode2") {
     if (file.exists(instExtdataPath) && md5sum(relativePath) != md5sum(instExtdataPath) &&
-        (!interactive() || !askYesNo(paste0("Replace ", instExtdataPath, " with ", relativePath, "?")))) {
+        (!interactive() || (requireNamespace("testthat", quietly = TRUE) && testthat::is_testing()) ||
+         !askYesNo(paste0("Replace ", instExtdataPath, " with ", relativePath, "?")))) {
       stop(relativePath, " != ", instExtdataPath)
     }
     file.copy(relativePath, instExtdataPath, overwrite = TRUE)

--- a/R/updateRepo.R
+++ b/R/updateRepo.R
@@ -107,7 +107,7 @@ updateRepo <- function(path = ".", check = TRUE, forceRebuild = FALSE, clean = F
         # move old tgz file into Archive for renv
         if (length(list.files(path, pattern = targzPattern)) > 1) {
           archivePath <- file.path(path, "Archive", packageName)
-          dir.create(archivePath, showWarnings = !dir.exists(archivePath))
+          dir.create(archivePath, recursive = TRUE, showWarnings = !dir.exists(archivePath))
           file.rename(file.path(path, targzBasename), file.path(archivePath, targzBasename))
         }
       } else {
@@ -130,13 +130,14 @@ updateRepo <- function(path = ".", check = TRUE, forceRebuild = FALSE, clean = F
       NULL
     }, error = function(error) error))
   })
+
   names(collectedErrors) <- basename(repoPaths)
   collectedErrors <- Filter(Negate(is.null), collectedErrors)
 
   write_PACKAGES(path, unpacked = TRUE)
 
   if (length(collectedErrors) >= 1) {
-    message("\nerrors:")
+    cat("\nerrors:\n")
     print(collectedErrors)
 
     stop("There were errors, see log (on RSE server with `journalctl -u update-repo.service`)")

--- a/R/updateRepo.R
+++ b/R/updateRepo.R
@@ -140,7 +140,7 @@ updateRepo <- function(path = ".", check = TRUE, forceRebuild = FALSE, clean = F
     cat("\nerrors:\n")
     print(collectedErrors)
 
-    stop("There were errors, see log (on RSE server with `journalctl -u update-repo.service`)")
+    stop("There were errors, see log (on RSE server with `journalctl -r -u update-repo.service`)")
   }
   message("done.")
 }

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Code Manipulation and Analysis Tools
 
-R package **lucode2**, version **0.29.3**
+R package **lucode2**, version **0.29.4**
 
 [![CRAN status](https://www.r-pkg.org/badges/version/lucode2)](https://cran.r-project.org/package=lucode2) [![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.4389418.svg)](https://doi.org/10.5281/zenodo.4389418) [![R build status](https://github.com/pik-piam/lucode2/workflows/check/badge.svg)](https://github.com/pik-piam/lucode2/actions) [![codecov](https://codecov.io/gh/pik-piam/lucode2/branch/master/graph/badge.svg)](https://app.codecov.io/gh/pik-piam/lucode2) [![r-universe](https://pik-piam.r-universe.dev/badges/lucode2)](https://pik-piam.r-universe.dev/ui#builds)
 
@@ -38,7 +38,7 @@ In case of questions / problems please contact Jan Philipp Dietrich <dietrich@pi
 
 To cite package **lucode2** in publications use:
 
-Dietrich J, Klein D, Giannousakis A, Bonsch M, Bodirsky B, Baumstark L, Führlich P (2022). _lucode2: Code Manipulation and Analysis Tools_. doi:10.5281/zenodo.4389418 <https://doi.org/10.5281/zenodo.4389418>, R package version 0.29.3, <https://github.com/pik-piam/lucode2>.
+Dietrich J, Klein D, Giannousakis A, Bonsch M, Bodirsky B, Baumstark L, Führlich P (2022). _lucode2: Code Manipulation and Analysis Tools_. doi:10.5281/zenodo.4389418 <https://doi.org/10.5281/zenodo.4389418>, R package version 0.29.4, <https://github.com/pik-piam/lucode2>.
 
 A BibTeX entry for LaTeX users is
 
@@ -47,7 +47,7 @@ A BibTeX entry for LaTeX users is
   title = {lucode2: Code Manipulation and Analysis Tools},
   author = {Jan Philipp Dietrich and David Klein and Anastasis Giannousakis and Markus Bonsch and Benjamin Leon Bodirsky and Lavinia Baumstark and Pascal Führlich},
   year = {2022},
-  note = {R package version 0.29.3},
+  note = {R package version 0.29.4},
   doi = {10.5281/zenodo.4389418},
   url = {https://github.com/pik-piam/lucode2},
 }

--- a/inst/extdata/lucode2-check.yaml
+++ b/inst/extdata/lucode2-check.yaml
@@ -77,7 +77,7 @@ jobs:
         run: |
           ./run.sh install_aptget libhdf5-dev libharfbuzz-dev libfribidi-dev
           ./run.sh install_all
-          ./run.sh install_r lucode2 covr rstudioapi
+          ./run.sh install_r lucode2 covr rstudioapi roxygen2
 
       - name: Install python dependencies if applicable
         run: |

--- a/inst/extdata/lucode2-check.yaml
+++ b/inst/extdata/lucode2-check.yaml
@@ -11,7 +11,7 @@ on:
 env:
   USE_BSPM: "true"
   _R_CHECK_FORCE_SUGGESTS_: "false"
-  NO_BINARY_INSTALL_R_PACKAGES: 'c("madrat", "magclass", "citation", "gms", "goxygen", "GDPuc")'
+  NO_BINARY_INSTALL_R_PACKAGES: 'c("madrat", "magclass", "citation", "gms", "goxygen", "GDPuc", "roxygen2")'
 
 jobs:
   lucode2-check:
@@ -77,7 +77,7 @@ jobs:
         run: |
           ./run.sh install_aptget libhdf5-dev libharfbuzz-dev libfribidi-dev
           ./run.sh install_all
-          ./run.sh install_r lucode2 covr rstudioapi roxygen2
+          ./run.sh install_r lucode2 covr rstudioapi
 
       - name: Install python dependencies if applicable
         run: |

--- a/inst/extdata/rUniversePackages.json
+++ b/inst/extdata/rUniversePackages.json
@@ -46,7 +46,6 @@
   "quitte",
   "rOpenscmRunner",
   "regressionworlddata",
-  "remind",
   "remind2",
   "remulator",
   "rmndt",

--- a/tests/testthat/test-updateRepo.R
+++ b/tests/testthat/test-updateRepo.R
@@ -7,7 +7,7 @@ test_that("updateRepo works", {
                     verbose = FALSE)
     expect_message({
       expect_error(updateRepo(reposFolder),
-                   "There were errors, see log (on RSE server with `journalctl -u update-repo.service`)",
+                   "There were errors, see log (on RSE server with `journalctl -r -u update-repo.service`)",
                    fixed = TRUE)
     }, "invalid validation key")
 

--- a/tests/testthat/test-updateRepo.R
+++ b/tests/testthat/test-updateRepo.R
@@ -16,7 +16,7 @@ test_that("updateRepo works", {
     expect_true(file.exists(file.path(reposFolder, "miniPackage_0.0.0.9000.tar.gz")))
     expect_true(file.exists(file.path(reposFolder, "PACKAGES")))
 
-    expect_message(updateRepo(reposFolder), "miniPackage 0.0.0.9000 ok")
+    expect_message(updateRepo(reposFolder), "miniPackage 0.0.0.9000 ok", fixed = TRUE)
     usethis::with_project(file.path(reposFolder, "miniPackage"), {
       usethis::use_version("major")
     })

--- a/tests/testthat/test-updateRepo.R
+++ b/tests/testthat/test-updateRepo.R
@@ -5,15 +5,22 @@ test_that("updateRepo works", {
     gert::git_clone("https://github.com/pik-piam/miniPackage.git",
                     file.path(reposFolder, "miniPackage"),
                     verbose = FALSE)
-    expect_output({
+    expect_message({
       expect_error(updateRepo(reposFolder),
-                  "There were errors, see log (on RSE server with `journalctl -u update-repo.service`)",
-                  fixed = TRUE)
+                   "There were errors, see log (on RSE server with `journalctl -u update-repo.service`)",
+                   fixed = TRUE)
     }, "invalid validation key")
 
     writeLines("ValidationKey: '173196000'", file.path(reposFolder, "miniPackage", ".buildlibrary"))
     updateRepo(reposFolder)
     expect_true(file.exists(file.path(reposFolder, "miniPackage_0.0.0.9000.tar.gz")))
     expect_true(file.exists(file.path(reposFolder, "PACKAGES")))
+
+    expect_message(updateRepo(reposFolder), "miniPackage 0.0.0.9000 ok")
+    usethis::with_project(file.path(reposFolder, "miniPackage"), {
+      usethis::use_version("major")
+    })
+    writeLines("ValidationKey: '1924400'", file.path(reposFolder, "miniPackage", ".buildlibrary"))
+    expect_message(updateRepo(reposFolder), "miniPackage 0.0.0.9000 -> 1.0.0 build success", fixed = TRUE)
   })
 })

--- a/tests/testthat/test-updateRepo.R
+++ b/tests/testthat/test-updateRepo.R
@@ -1,0 +1,19 @@
+test_that("updateRepo works", {
+  capture.output({
+    reposFolder <- withr::local_tempdir()
+
+    gert::git_clone("https://github.com/pik-piam/miniPackage.git",
+                    file.path(reposFolder, "miniPackage"),
+                    verbose = FALSE)
+    expect_output({
+      expect_error(updateRepo(reposFolder),
+                  "There were errors, see log (on RSE server with `journalctl -u update-repo.service`)",
+                  fixed = TRUE)
+    }, "invalid validation key")
+
+    writeLines("ValidationKey: '173196000'", file.path(reposFolder, "miniPackage", ".buildlibrary"))
+    updateRepo(reposFolder)
+    expect_true(file.exists(file.path(reposFolder, "miniPackage_0.0.0.9000.tar.gz")))
+    expect_true(file.exists(file.path(reposFolder, "PACKAGES")))
+  })
+})


### PR DESCRIPTION
The mattermost bot we set up a while ago does not message us on erros, because updateRepo would always catch all errors. Now it will catch and collect all errors at first and then throw them before returning if there were any.