### PR TITLE
add possibility for command line flags to readArgs

### DIFF
--- a/.buildlibrary
+++ b/.buildlibrary
@@ -1,4 +1,4 @@
-ValidationKey: '5658912'
+ValidationKey: '5775300'
 AutocreateReadme: yes
 AcceptedWarnings:
 - 'Warning: package ''.*'' was built under R version'

--- a/.zenodo.json
+++ b/.zenodo.json
@@ -1,6 +1,6 @@
 {
   "title": "lucode2: Code Manipulation and Analysis Tools",
-  "version": "0.29.4",
+  "version": "0.30.0",
   "description": "<p>A collection of tools which allow to manipulate and analyze code.<\/p>",
   "creators": [
     {
@@ -23,6 +23,9 @@
     },
     {
       "name": "Führlich, Pascal"
+    },
+    {
+      "name": "Richters, Oliver"
     }
   ]
 }

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,15 +1,16 @@
 Package: lucode2
 Type: Package
 Title: Code Manipulation and Analysis Tools
-Version: 0.29.4
-Date: 2022-09-13
+Version: 0.30.0
+Date: 2022-09-16
 Authors@R: c(person("Jan Philipp", "Dietrich", email = "dietrich@pik-potsdam.de", role = c("aut","cre")),
              person("David", "Klein", role = "aut"),
              person("Anastasis", "Giannousakis", role = "aut"),
              person("Markus", "Bonsch", role = "aut"),
              person("Benjamin Leon", "Bodirsky", role = "aut"),
              person("Lavinia", "Baumstark", role = "aut"),
-             person("Pascal", "Führlich", role = "aut"))
+             person("Pascal", "Führlich", role = "aut"),
+             person("Oliver", "Richters", role = "aut"))
 Description: A collection of tools which allow to manipulate and analyze code.
 Imports:
     callr,

--- a/R/lint.R
+++ b/R/lint.R
@@ -16,7 +16,9 @@
 #' @importFrom lintr lint_package
 #' @importFrom withr with_dir
 #' @examples
+#' \dontrun{
 #' lucode2::lint()
+#' }
 #' @export
 lint <- function(files = getFilesToLint()) {
   # create .lintr config files if they do not exist

--- a/R/readArgs.R
+++ b/R/readArgs.R
@@ -6,6 +6,8 @@
 #' @param \dots arguments allowed to be read from command line (other values
 #' are ignored). Value is set if found on command line input, nothing is done,
 #' if value is not found.
+#' @param .argv command line arguments, usually read with commandArgs, can be specified
+#' for testing purposes
 #' @param .envir environment in which the variables should be written (by
 #' default the environment from which the function is called)
 #' @param .flags named vector with possible command line switches. Element names
@@ -22,14 +24,14 @@
 #' value1 <- "old"
 #' value2 <- 2
 #' value3 <- "willstaythesame"
-#' argv <- readArgs("value1", "value2", "value4", .flags = c(t = "--test", p = "--parallel"))
+#' flags <- readArgs("value1", "value2", "value4", .flags = c(t = "--test", p = "--parallel"))
 #' message(value1)
 #' message(value2)
 #' message(value3)
-#' if ("--test" %in% argv) {
+#' if ("--test" %in% flags) {
 #'   message("You are in test mode")
 #' }
-#' if ("--parallel" %in% argv) {
+#' if ("--parallel" %in% flags) {
 #'   message("You are in parallel mode")
 #' }
 #'
@@ -42,7 +44,7 @@
 #' # value1 <- new
 #' # value2 <- 3
 #' # value4 not found
-#' # All flags: --parallel, --test
+#' # Flags: --parallel, --test
 #' # ### READ COMMAND LINE - CONFIGURATION END ###
 #' #
 #' # new
@@ -53,22 +55,22 @@
 #'
 #'
 #' ### function that reads all allowed arguments from command line ###
-readArgs <- function(..., .envir = parent.frame(), .silent = FALSE, .flags = NULL) {
+readArgs <- function(..., .argv = commandArgs(trailingOnly = TRUE),
+                          .envir = parent.frame(), .flags = NULL, .silent = FALSE) {
   allowedArgs <- c(...)
-  argv <- commandArgs(trailingOnly = TRUE)
   # search for strings that look like -i1asrR and transform them into long flags
-  oneDashFlags <- unlist(strsplit(paste0(argv[grepl("^-[a-zA-Z0-9]*$", argv)], collapse = ""), split = ""))
-  twoDashFlags <- argv[grepl("^--[a-zA-Z0-9]*$", argv) & argv %in% .flags]
+  oneDashFlags <- unlist(strsplit(paste0(.argv[grepl("^-[a-zA-Z0-9]*$", .argv)], collapse = ""), split = ""))
+  twoDashFlags <- .argv[grepl("^--[a-zA-Z0-9]*$", .argv) & .argv %in% .flags]
   knownFlags <- sort(unique(c(twoDashFlags, unlist(.flags[names(.flags) %in% oneDashFlags]))))
   unknownFlags <- c(sort(paste0("-", oneDashFlags)[! oneDashFlags %in% c(names(.flags), "-")]),
-                    argv[grepl("^--[a-zA-Z0-9]*$", argv) & ! argv %in% .flags])
-  argv <- argv[! grepl("^-", argv)]
-  if (length(argv) > 0) {
+                    .argv[grepl("^--[a-zA-Z0-9]*$", .argv) & ! .argv %in% .flags])
+  .argv <- .argv[! grepl("^-", .argv)]
+  if (length(.argv) > 0) {
     ### apply additional command line arguments ###
-    for (argnr in seq_along(argv)) {
+    for (argnr in seq_along(.argv)) {
       for (i in seq_along(allowedArgs)) {
-        if (strsplit(argv[argnr], "=")[[1]][1] == allowedArgs[i]) {
-          assign(allowedArgs[i], extract_arguments(argv[argnr]), envir = .envir)
+        if (strsplit(.argv[argnr], "=")[[1]][1] == allowedArgs[i]) {
+          assign(allowedArgs[i], extract_arguments(.argv[argnr]), envir = .envir)
         }
       }
     }

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Code Manipulation and Analysis Tools
 
-R package **lucode2**, version **0.29.4**
+R package **lucode2**, version **0.30.0**
 
 [![CRAN status](https://www.r-pkg.org/badges/version/lucode2)](https://cran.r-project.org/package=lucode2) [![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.4389418.svg)](https://doi.org/10.5281/zenodo.4389418) [![R build status](https://github.com/pik-piam/lucode2/workflows/check/badge.svg)](https://github.com/pik-piam/lucode2/actions) [![codecov](https://codecov.io/gh/pik-piam/lucode2/branch/master/graph/badge.svg)](https://app.codecov.io/gh/pik-piam/lucode2) [![r-universe](https://pik-piam.r-universe.dev/badges/lucode2)](https://pik-piam.r-universe.dev/ui#builds)
 
@@ -38,16 +38,16 @@ In case of questions / problems please contact Jan Philipp Dietrich <dietrich@pi
 
 To cite package **lucode2** in publications use:
 
-Dietrich J, Klein D, Giannousakis A, Bonsch M, Bodirsky B, Baumstark L, Führlich P (2022). _lucode2: Code Manipulation and Analysis Tools_. doi:10.5281/zenodo.4389418 <https://doi.org/10.5281/zenodo.4389418>, R package version 0.29.4, <https://github.com/pik-piam/lucode2>.
+Dietrich J, Klein D, Giannousakis A, Bonsch M, Bodirsky B, Baumstark L, Führlich P, Richters O (2022). _lucode2: Code Manipulation and Analysis Tools_. doi: 10.5281/zenodo.4389418 (URL: https://doi.org/10.5281/zenodo.4389418), R package version 0.30.0, <URL: https://github.com/pik-piam/lucode2>.
 
 A BibTeX entry for LaTeX users is
 
  ```latex
 @Manual{,
   title = {lucode2: Code Manipulation and Analysis Tools},
-  author = {Jan Philipp Dietrich and David Klein and Anastasis Giannousakis and Markus Bonsch and Benjamin Leon Bodirsky and Lavinia Baumstark and Pascal Führlich},
+  author = {Jan Philipp Dietrich and David Klein and Anastasis Giannousakis and Markus Bonsch and Benjamin Leon Bodirsky and Lavinia Baumstark and Pascal Führlich and Oliver Richters},
   year = {2022},
-  note = {R package version 0.29.4},
+  note = {R package version 0.30.0},
   doi = {10.5281/zenodo.4389418},
   url = {https://github.com/pik-piam/lucode2},
 }

--- a/man/lint.Rd
+++ b/man/lint.Rd
@@ -23,7 +23,9 @@ leads to a linter warning, but not in vignettes/tests. Which linter rules are us
 ".lintr" config files. \code{\link{check}} creates lintr config files that use \code{\link{lintrRules}}.
 }
 \examples{
+\dontrun{
 lucode2::lint()
+}
 }
 \seealso{
 \code{\link{getFilesToLint}}, \code{\link{lintrRules}}, \code{\link{autoFormat}}, \code{\link[lintr]{lint}}

--- a/man/lucode2-package.Rd
+++ b/man/lucode2-package.Rd
@@ -28,6 +28,7 @@ Authors:
   \item Benjamin Leon Bodirsky
   \item Lavinia Baumstark
   \item Pascal Führlich
+  \item Oliver Richters
 }
 
 }

--- a/man/readArgs.Rd
+++ b/man/readArgs.Rd
@@ -4,21 +4,30 @@
 \alias{readArgs}
 \title{Read Arguments from command line}
 \usage{
-readArgs(..., .envir = parent.frame(), .silent = FALSE, .flags = NULL)
+readArgs(
+  ...,
+  .argv = commandArgs(trailingOnly = TRUE),
+  .envir = parent.frame(),
+  .flags = NULL,
+  .silent = FALSE
+)
 }
 \arguments{
 \item{\dots}{arguments allowed to be read from command line (other values
 are ignored). Value is set if found on command line input, nothing is done,
 if value is not found.}
 
+\item{.argv}{command line arguments, usually read with commandArgs, can be specified
+for testing purposes}
+
 \item{.envir}{environment in which the variables should be written (by
 default the environment from which the function is called)}
-
-\item{.silent}{boolean which allows to suppress status messages}
 
 \item{.flags}{named vector with possible command line switches. Element names
 are short flags used with one dash, corresponding elements the long form
 including two dashes: c(t = "--test") will interpret "-t" in command line as "--test"}
+
+\item{.silent}{boolean which allows to suppress status messages}
 }
 \value{
 vector of activated flags, if any
@@ -33,14 +42,14 @@ and transforms them to R-Values, if they are called as allowed arguments.
 value1 <- "old"
 value2 <- 2
 value3 <- "willstaythesame"
-argv <- readArgs("value1", "value2", "value4", .flags = c(t = "--test", p = "--parallel"))
+flags <- readArgs("value1", "value2", "value4", .flags = c(t = "--test", p = "--parallel"))
 message(value1)
 message(value2)
 message(value3)
-if ("--test" \%in\% argv) {
+if ("--test" \%in\% flags) {
   message("You are in test mode")
 }
-if ("--parallel" \%in\% argv) {
+if ("--parallel" \%in\% flags) {
   message("You are in parallel mode")
 }
 
@@ -53,7 +62,7 @@ if ("--parallel" \%in\% argv) {
 # value1 <- new
 # value2 <- 3
 # value4 not found
-# All flags: --parallel, --test
+# Flags: --parallel, --test
 # ### READ COMMAND LINE - CONFIGURATION END ###
 #
 # new

--- a/man/readArgs.Rd
+++ b/man/readArgs.Rd
@@ -4,7 +4,7 @@
 \alias{readArgs}
 \title{Read Arguments from command line}
 \usage{
-readArgs(..., .envir = parent.frame(), .silent = FALSE)
+readArgs(..., .envir = parent.frame(), .silent = FALSE, .flags = NULL)
 }
 \arguments{
 \item{\dots}{arguments allowed to be read from command line (other values
@@ -15,6 +15,13 @@ if value is not found.}
 default the environment from which the function is called)}
 
 \item{.silent}{boolean which allows to suppress status messages}
+
+\item{.flags}{named vector with possible command line switches. Element names
+are short flags used with one dash, corresponding elements the long form
+including two dashes: c(t = "--test") will interpret "-t" in command line as "--test"}
+}
+\value{
+vector of activated flags, if any
 }
 \description{
 Function reads arguments from command line of the structure value=content
@@ -26,13 +33,19 @@ and transforms them to R-Values, if they are called as allowed arguments.
 value1 <- "old"
 value2 <- 2
 value3 <- "willstaythesame"
-readArgs("value1", "value2", "value4")
-cat(value1, "\n")
-cat(value2, "\n")
-cat(value3, "\n")
+argv <- readArgs("value1", "value2", "value4", .flags = c(t = "--test", p = "--parallel"))
+message(value1)
+message(value2)
+message(value3)
+if ("--test" \%in\% argv) {
+  message("You are in test mode")
+}
+if ("--parallel" \%in\% argv) {
+  message("You are in parallel mode")
+}
 
 # Open the command line and execute the following code:
-# Rscript test.R value1=new value2=3 value3=isnotallowed
+# Rscript test.R -t --parallel value1=new value2=3 value3=isnotallowed
 
 # Output:
 #
@@ -40,18 +53,21 @@ cat(value3, "\n")
 # value1 <- new
 # value2 <- 3
 # value4 not found
+# All flags: --parallel, --test
 # ### READ COMMAND LINE - CONFIGURATION END ###
 #
-# "new"
+# new
 # 3
-# "willstaythesame"
+# willstaythesame
+# You are in test mode
+# You are in parallel mode
 
 
-### function that reads all allowed arguments from command line###
+### function that reads all allowed arguments from command line ###
 }
 \seealso{
 \code{\link{manipulateConfig}}
 }
 \author{
-Jan Philipp Dietrich
+Jan Philipp Dietrich, Oliver Richters
 }

--- a/tests/testthat/test-readArgs.R
+++ b/tests/testthat/test-readArgs.R
@@ -1,0 +1,23 @@
+test_that("Check readArgs", {
+  value1 <- "old"
+  value2 <- 2
+  value3 <- "willstaythesame"
+  flags <- readArgs("value1", "value2", "value4", .flags = c(t = "--test", p = "--parallel"),
+                    .argv = c("-t", "--blablub", "--parallel", "value1=new", "value2=3", "value3=isnotallowed"))
+  expect_true("--test" %in% flags)
+  expect_true("--parallel" %in% flags)
+  expect_false("--blablub" %in% flags)
+  expect_false("-t" %in% flags)
+  expect_identical(value1, "new")
+  expect_identical(value2, 3)
+  expect_identical(value3, "willstaythesame")
+  expect_false(exists("value4"))
+  expect_message(readArgs(), "### READ COMMAND LINE - ASSIGNED CONFIGURATION ###")
+  expect_message(readArgs(), "### READ COMMAND LINE - CONFIGURATION END ###")
+  expect_message(readArgs("value1", .argv = c("value1=new")), "value1 <- new")
+  expect_message(readArgs("value2", .argv = c("value2=3")), c("value2 <- 3"))
+  expect_message(readArgs("value4", .argv = NULL), c("value4 not found"))
+  expect_message(readArgs(.flags = c(t = "--test"), .argv = c("--test")), "Flags: --test")
+  expect_message(readArgs(.flags = c(t = "--test", p = "--parallel"), .argv = c("-tp")), "Flags: --parallel, --test")
+  expect_message(readArgs(.argv = c("--blablub")), "Unknown flags: --blablub")
+})


### PR DESCRIPTION
in REMIND start.R, start_bundle_coupled.R, we use command line flags such as `--test` or `--parallel` to influence the script behavior. Instead of reimplementing it each time, add it to readArgs: You can then add a `.flags` argument with something like `argv <- lucode2::readArgs(.flags = c(t = "--test", p = "--parallel"))` and if you add `-pt` or `-p -t` or `--parallel` or `--test` to the command line while starting the scripts, these are recognized and returned as a vector which can then be checked with `if ("--test" %in% argv)`.

It can substitute scripts such as [this part](https://github.com/remindmodel/remind/blob/3b9f369c4b5cd32d01e9c3e541b5dc4f2c9d0e4f/start.R#L174-L185) in start.R