### PR TITLE
Invalidate caches

### DIFF
--- a/.buildlibrary
+++ b/.buildlibrary
@@ -1,4 +1,4 @@
-ValidationKey: '6364380'
+ValidationKey: '6384659'
 AutocreateReadme: yes
 AcceptedWarnings:
 - 'Warning: package ''.*'' was built under R version'

--- a/.github/workflows/lucode2-check.yaml
+++ b/.github/workflows/lucode2-check.yaml
@@ -67,9 +67,9 @@ jobs:
         uses: pat-s/always-upload-cache@v3
         with:
           path: /usr/local/lib/R/
-          key: ${{ runner.os }}-usr-local-lib-R-${{ hashFiles('DESCRIPTION') }}
+          key: 2-${{ runner.os }}-usr-local-lib-R-${{ hashFiles('DESCRIPTION') }}
           restore-keys: |
-            ${{ runner.os }}-usr-local-lib-R-
+            2-${{ runner.os }}-usr-local-lib-R-
 
       - name: Restore R library permissions
         run: |

--- a/.zenodo.json
+++ b/.zenodo.json
@@ -1,6 +1,6 @@
 {
   "title": "lucode2: Code Manipulation and Analysis Tools",
-  "version": "0.33.0",
+  "version": "0.33.1",
   "description": "<p>A collection of tools which allow to manipulate and analyze code.<\/p>",
   "creators": [
     {

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Package: lucode2
 Type: Package
 Title: Code Manipulation and Analysis Tools
-Version: 0.33.0
-Date: 2022-10-21
+Version: 0.33.1
+Date: 2022-10-24
 Authors@R: c(person("Jan Philipp", "Dietrich", email = "dietrich@pik-potsdam.de", role = c("aut","cre")),
              person("David", "Klein", role = "aut"),
              person("Anastasis", "Giannousakis", role = "aut"),

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Code Manipulation and Analysis Tools
 
-R package **lucode2**, version **0.33.0**
+R package **lucode2**, version **0.33.1**
 
 [![CRAN status](https://www.r-pkg.org/badges/version/lucode2)](https://cran.r-project.org/package=lucode2) [![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.4389418.svg)](https://doi.org/10.5281/zenodo.4389418) [![R build status](https://github.com/pik-piam/lucode2/workflows/check/badge.svg)](https://github.com/pik-piam/lucode2/actions) [![codecov](https://codecov.io/gh/pik-piam/lucode2/branch/master/graph/badge.svg)](https://app.codecov.io/gh/pik-piam/lucode2) [![r-universe](https://pik-piam.r-universe.dev/badges/lucode2)](https://pik-piam.r-universe.dev/ui#builds)
 
@@ -38,7 +38,7 @@ In case of questions / problems please contact Jan Philipp Dietrich <dietrich@pi
 
 To cite package **lucode2** in publications use:
 
-Dietrich J, Klein D, Giannousakis A, Bonsch M, Bodirsky B, Baumstark L, Führlich P, Richters O (2022). _lucode2: Code Manipulation and Analysis Tools_. doi:10.5281/zenodo.4389418 <https://doi.org/10.5281/zenodo.4389418>, R package version 0.33.0, <https://github.com/pik-piam/lucode2>.
+Dietrich J, Klein D, Giannousakis A, Bonsch M, Bodirsky B, Baumstark L, Führlich P, Richters O (2022). _lucode2: Code Manipulation and Analysis Tools_. doi:10.5281/zenodo.4389418 <https://doi.org/10.5281/zenodo.4389418>, R package version 0.33.1, <https://github.com/pik-piam/lucode2>.
 
 A BibTeX entry for LaTeX users is
 
@@ -47,7 +47,7 @@ A BibTeX entry for LaTeX users is
   title = {lucode2: Code Manipulation and Analysis Tools},
   author = {Jan Philipp Dietrich and David Klein and Anastasis Giannousakis and Markus Bonsch and Benjamin Leon Bodirsky and Lavinia Baumstark and Pascal Führlich and Oliver Richters},
   year = {2022},
-  note = {R package version 0.33.0},
+  note = {R package version 0.33.1},
   doi = {10.5281/zenodo.4389418},
   url = {https://github.com/pik-piam/lucode2},
 }

--- a/inst/extdata/lucode2-check.yaml
+++ b/inst/extdata/lucode2-check.yaml
@@ -67,9 +67,9 @@ jobs:
         uses: pat-s/always-upload-cache@v3
         with:
           path: /usr/local/lib/R/
-          key: ${{ runner.os }}-usr-local-lib-R-${{ hashFiles('DESCRIPTION') }}
+          key: 2-${{ runner.os }}-usr-local-lib-R-${{ hashFiles('DESCRIPTION') }}
           restore-keys: |
-            ${{ runner.os }}-usr-local-lib-R-
+            2-${{ runner.os }}-usr-local-lib-R-
 
       - name: Restore R library permissions
         run: |

--- a/man/checkDeps.Rd
+++ b/man/checkDeps.Rd
@@ -2,32 +2,38 @@
 % Please edit documentation in R/checkDeps.R
 \name{checkDeps}
 \alias{checkDeps}
-\title{checkDeps}
+\title{Check Dependencies}
 \usage{
 checkDeps(
   descriptionFile = ".",
-  dependencyTypes = c("Depends", "Imports", "LinkingTo")
+  dependencyTypes = c("Depends", "Imports", "LinkingTo"),
+  action = "stop"
 )
 }
 \arguments{
-\item{descriptionFile}{Path to a DESCRIPTION or a path that belongs to a source package project.}
+\item{descriptionFile}{Path to a DESCRIPTION file or a path that belongs to a
+source package project.}
 
-\item{dependencyTypes}{The types of depencies to check. Must be a
-subset of c("Depends", "Imports", "LinkingTo", "Suggests", "Enhances").}
+\item{dependencyTypes}{The types of dependencies to check. Must be a
+subset of \code{c("Depends", "Imports", "LinkingTo", "Suggests", "Enhances")}.}
+
+\item{action}{Action to take on unmet dependencies:
+\itemize{
+\item \code{"stop"}:  Issue an error with the unmet dependencies.  (Default.)
+\item \code{"warn"}:  Issue a warning with the unmet dependencies.
+\item \code{"pass"}:  Do nothing, just return invisibly.
+}}
 }
 \value{
-Invisibly, a named logical vector indicating whether each package requirement is met.
+Invisibly, a named list of strings indicating whether each package
+requirement is met (\code{"TRUE"}) or not, in which case the reason is stated.
 }
 \description{
 Check if package requirements specified in the given DESCRIPTION are met.
 }
-\details{
-A warning is thrown for each required package that is not installed, and
-each installed package whose version number is lower than what is required.
-Only ">=" version requirements are supported.
-}
 \examples{
 checkDeps(system.file("DESCRIPTION", package = "lucode2"))
+
 }
 \author{
 Pascal Führlich


### PR DESCRIPTION
Some caches in github actions are broken (e.g. https://github.com/pik-piam/gms/actions/runs/3312621942/jobs/5469522390 ), and they won't fix itself as long as there is at least one pull request per week. The official documented way to invalidate caches is to change the cache key so it will automatically generate and use new ones, and the old ones will be evicted after one week automatically.

Therefore, prepend a version number to the cache key. That will invalidate caches in all packages on the next `buildLibrary()`, so will fix gms actions, and lead to longer check times in all packages for the first PR after the change. I think that is fine (doing something especially for gms sounds like a lot of complexity for little gain, just avoiding a one-time increase in check times in all packages).