### PR TITLE
allow linter rules modification

### DIFF
--- a/.buildlibrary
+++ b/.buildlibrary
@@ -1,4 +1,4 @@
-ValidationKey: '8139614'
+ValidationKey: '8317060'
 AutocreateReadme: yes
 AcceptedWarnings:
 - 'Warning: package ''.*'' was built under R version'

--- a/.zenodo.json
+++ b/.zenodo.json
@@ -1,6 +1,6 @@
 {
   "title": "lucode2: Code Manipulation and Analysis Tools",
-  "version": "0.42.1",
+  "version": "0.43.0",
   "description": "<p>A collection of tools which allow to manipulate and analyze\n    code.<\/p>",
   "creators": [
     {

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Type: Package
 Package: lucode2
 Title: Code Manipulation and Analysis Tools
-Version: 0.42.1
-Date: 2022-12-08
+Version: 0.43.0
+Date: 2022-12-16
 Authors@R: c(
     person("Jan Philipp", "Dietrich", , "dietrich@pik-potsdam.de", role = c("aut", "cre")),
     person("Pascal", "Führlich", role = "aut"),
@@ -49,4 +49,4 @@ Suggests:
     testthat
 Encoding: UTF-8
 LazyData: no
-RoxygenNote: 7.2.2
+RoxygenNote: 7.2.3

--- a/R/lintrRules.R
+++ b/R/lintrRules.R
@@ -3,18 +3,31 @@
 #' This function defines the rules to be used by the linter called lintr. \code{\link{check}} creates ".lintr"
 #' config files that use this function.
 #'
+#' To change which linters are applied for a package edit the .lintr file to use the modification
+#' argument, see example.
+#'
 #' @param allowUndesirable If true it is okay to use undesirable operators (such as "<<-")
 #' and undesirable (but not deprecated) functions (such as "setwd").
+#' @param modification A named list mapping linter names to NULL (removes that linter)
+#' or a corresponding linter function. Will be applied to the result with utils::modifyList.
+#' @return A named list mapping linter names to linter functions.
 #'
 #' @examples
-#' \dontrun{lintr::lint_dir(linters = lintrRules())}
+#' \dontrun{
+#' lintr::lint_dir(linters = lucode2::lintrRules())
+#'
+#' # return usual linters with a different object_name_linter and without the todo_comment_linter
+#' snakeCaseLinter <- lintr::object_name_linter(styles = "snake_case")
+#' lucode2::lintrRules(modification = list(object_name_linter = snakeCaseLinter,
+#'                                         todo_comment_linter = NULL))
+#' }
 #'
 #' @importFrom lintr linters_with_defaults absolute_path_linter line_length_linter object_name_linter
 #' todo_comment_linter undesirable_function_linter cyclocomp_linter default_undesirable_functions
 #' undesirable_operator_linter default_undesirable_operators T_and_F_symbol_linter object_length_linter
 #' @seealso \code{\link{check}}, \code{\link{lint}}
 #' @export
-lintrRules <- function(allowUndesirable = FALSE) {
+lintrRules <- function(allowUndesirable = FALSE, modification = list()) {
   # names = deprecated functions, values = replacement hint
   deprecatedFunctions <- list(fulldim = "use magclass::getItems()",
                               getRegionList = "use magclass::getItems()",
@@ -47,5 +60,6 @@ lintrRules <- function(allowUndesirable = FALSE) {
                                                                          undesirableFunctions,
                                                                          deprecatedFunctions))
   }
+  linters <- utils::modifyList(linters, modification)
   return(linters)
 }

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Code Manipulation and Analysis Tools
 
-R package **lucode2**, version **0.42.1**
+R package **lucode2**, version **0.43.0**
 
 [![CRAN status](https://www.r-pkg.org/badges/version/lucode2)](https://cran.r-project.org/package=lucode2) [![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.4389418.svg)](https://doi.org/10.5281/zenodo.4389418) [![R build status](https://github.com/pik-piam/lucode2/workflows/check/badge.svg)](https://github.com/pik-piam/lucode2/actions) [![codecov](https://codecov.io/gh/pik-piam/lucode2/branch/master/graph/badge.svg)](https://app.codecov.io/gh/pik-piam/lucode2) [![r-universe](https://pik-piam.r-universe.dev/badges/lucode2)](https://pik-piam.r-universe.dev/ui#builds)
 
@@ -39,7 +39,7 @@ In case of questions / problems please contact Jan Philipp Dietrich <dietrich@pi
 
 To cite package **lucode2** in publications use:
 
-Dietrich J, Führlich P, Klein D, Giannousakis A, Bonsch M, Bodirsky B, Baumstark L, Richters O, Pflüger M (2022). _lucode2: Code Manipulation and Analysis Tools_. doi:10.5281/zenodo.4389418 <https://doi.org/10.5281/zenodo.4389418>, R package version 0.42.1, <https://github.com/pik-piam/lucode2>.
+Dietrich J, Führlich P, Klein D, Giannousakis A, Bonsch M, Bodirsky B, Baumstark L, Richters O, Pflüger M (2022). _lucode2: Code Manipulation and Analysis Tools_. doi:10.5281/zenodo.4389418 <https://doi.org/10.5281/zenodo.4389418>, R package version 0.43.0, <https://github.com/pik-piam/lucode2>.
 
 A BibTeX entry for LaTeX users is
 
@@ -48,7 +48,7 @@ A BibTeX entry for LaTeX users is
   title = {lucode2: Code Manipulation and Analysis Tools},
   author = {Jan Philipp Dietrich and Pascal Führlich and David Klein and Anastasis Giannousakis and Markus Bonsch and Benjamin Leon Bodirsky and Lavinia Baumstark and Oliver Richters and Mika Pflüger},
   year = {2022},
-  note = {R package version 0.42.1},
+  note = {R package version 0.43.0},
   doi = {10.5281/zenodo.4389418},
   url = {https://github.com/pik-piam/lucode2},
 }

--- a/man/lintrRules.Rd
+++ b/man/lintrRules.Rd
@@ -4,18 +4,35 @@
 \alias{lintrRules}
 \title{lintrRules}
 \usage{
-lintrRules(allowUndesirable = FALSE)
+lintrRules(allowUndesirable = FALSE, modification = list())
 }
 \arguments{
 \item{allowUndesirable}{If true it is okay to use undesirable operators (such as "<<-")
 and undesirable (but not deprecated) functions (such as "setwd").}
+
+\item{modification}{A named list mapping linter names to NULL (removes that linter)
+or a corresponding linter function. Will be applied to the result with utils::modifyList.}
+}
+\value{
+A named list mapping linter names to linter functions.
 }
 \description{
 This function defines the rules to be used by the linter called lintr. \code{\link{check}} creates ".lintr"
 config files that use this function.
 }
+\details{
+To change which linters are applied for a package edit the .lintr file to use the modification
+argument, see example.
+}
 \examples{
-\dontrun{lintr::lint_dir(linters = lintrRules())}
+\dontrun{
+lintr::lint_dir(linters = lucode2::lintrRules())
+
+# return usual linters with a different object_name_linter and without the todo_comment_linter
+snakeCaseLinter <- lintr::object_name_linter(styles = "snake_case")
+lucode2::lintrRules(modification = list(object_name_linter = snakeCaseLinter,
+                                        todo_comment_linter = NULL))
+}
 
 }
 \seealso{


### PR DESCRIPTION
This PR allows modifications to the set of linter rules in a `.lintr` file. This feature must not be used in the default configuration of a package unless it was discussed with RSE.