### PR TITLE
Invalidate caches again

### DIFF
--- a/.buildlibrary
+++ b/.buildlibrary
@@ -1,4 +1,4 @@
-ValidationKey: '8317060'
+ValidationKey: '8338557'
 AutocreateReadme: yes
 AcceptedWarnings:
 - 'Warning: package ''.*'' was built under R version'

--- a/.github/workflows/lucode2-check.yaml
+++ b/.github/workflows/lucode2-check.yaml
@@ -67,9 +67,9 @@ jobs:
         uses: pat-s/always-upload-cache@v3
         with:
           path: /usr/local/lib/R/
-          key: 2-${{ runner.os }}-usr-local-lib-R-${{ hashFiles('DESCRIPTION') }}
+          key: 3-${{ runner.os }}-usr-local-lib-R-${{ hashFiles('DESCRIPTION') }}
           restore-keys: |
-            2-${{ runner.os }}-usr-local-lib-R-
+            3-${{ runner.os }}-usr-local-lib-R-
 
       - name: Restore R library permissions
         run: |

--- a/.zenodo.json
+++ b/.zenodo.json
@@ -1,6 +1,6 @@
 {
   "title": "lucode2: Code Manipulation and Analysis Tools",
-  "version": "0.43.0",
+  "version": "0.43.1",
   "description": "<p>A collection of tools which allow to manipulate and analyze\n    code.<\/p>",
   "creators": [
     {

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Type: Package
 Package: lucode2
 Title: Code Manipulation and Analysis Tools
-Version: 0.43.0
-Date: 2022-12-16
+Version: 0.43.1
+Date: 2022-12-21
 Authors@R: c(
     person("Jan Philipp", "Dietrich", , "dietrich@pik-potsdam.de", role = c("aut", "cre")),
     person("Pascal", "Führlich", role = "aut"),

--- a/R/autoFormat.R
+++ b/R/autoFormat.R
@@ -42,7 +42,7 @@ theOneAndOnlyTandFsymbolFixer <- function(files) {
 
   # get all files with this kind of lint
   theLint <- lapply(files, lintr::lint,
-                    linters = list(lintr::T_and_F_symbol_linter()))
+                    linters = list(lintr::T_and_F_symbol_linter()), parse_settings = FALSE)
 
   # for each file
   for (f in theLint) {

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Code Manipulation and Analysis Tools
 
-R package **lucode2**, version **0.43.0**
+R package **lucode2**, version **0.43.1**
 
 [![CRAN status](https://www.r-pkg.org/badges/version/lucode2)](https://cran.r-project.org/package=lucode2) [![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.4389418.svg)](https://doi.org/10.5281/zenodo.4389418) [![R build status](https://github.com/pik-piam/lucode2/workflows/check/badge.svg)](https://github.com/pik-piam/lucode2/actions) [![codecov](https://codecov.io/gh/pik-piam/lucode2/branch/master/graph/badge.svg)](https://app.codecov.io/gh/pik-piam/lucode2) [![r-universe](https://pik-piam.r-universe.dev/badges/lucode2)](https://pik-piam.r-universe.dev/ui#builds)
 
@@ -39,7 +39,7 @@ In case of questions / problems please contact Jan Philipp Dietrich <dietrich@pi
 
 To cite package **lucode2** in publications use:
 
-Dietrich J, Führlich P, Klein D, Giannousakis A, Bonsch M, Bodirsky B, Baumstark L, Richters O, Pflüger M (2022). _lucode2: Code Manipulation and Analysis Tools_. doi:10.5281/zenodo.4389418 <https://doi.org/10.5281/zenodo.4389418>, R package version 0.43.0, <https://github.com/pik-piam/lucode2>.
+Dietrich J, Führlich P, Klein D, Giannousakis A, Bonsch M, Bodirsky B, Baumstark L, Richters O, Pflüger M (2022). _lucode2: Code Manipulation and Analysis Tools_. doi:10.5281/zenodo.4389418 <https://doi.org/10.5281/zenodo.4389418>, R package version 0.43.1, <https://github.com/pik-piam/lucode2>.
 
 A BibTeX entry for LaTeX users is
 
@@ -48,7 +48,7 @@ A BibTeX entry for LaTeX users is
   title = {lucode2: Code Manipulation and Analysis Tools},
   author = {Jan Philipp Dietrich and Pascal Führlich and David Klein and Anastasis Giannousakis and Markus Bonsch and Benjamin Leon Bodirsky and Lavinia Baumstark and Oliver Richters and Mika Pflüger},
   year = {2022},
-  note = {R package version 0.43.0},
+  note = {R package version 0.43.1},
   doi = {10.5281/zenodo.4389418},
   url = {https://github.com/pik-piam/lucode2},
 }

--- a/inst/extdata/lucode2-check.yaml
+++ b/inst/extdata/lucode2-check.yaml
@@ -67,9 +67,9 @@ jobs:
         uses: pat-s/always-upload-cache@v3
         with:
           path: /usr/local/lib/R/
-          key: 2-${{ runner.os }}-usr-local-lib-R-${{ hashFiles('DESCRIPTION') }}
+          key: 3-${{ runner.os }}-usr-local-lib-R-${{ hashFiles('DESCRIPTION') }}
           restore-keys: |
-            2-${{ runner.os }}-usr-local-lib-R-
+            3-${{ runner.os }}-usr-local-lib-R-
 
       - name: Restore R library permissions
         run: |


### PR DESCRIPTION
Github actions are  - again - persistently broken because some cache is broken, see e.g. https://github.com/pik-piam/mrcommons/actions/runs/3748016612/jobs/6364875349 .

Also do not parse settings in `lintr::lint` in `theOneAndOnlyTandFSymbolFixer`  because the lintr people deprecated lintr::with_defaults, but continue to use it themselves in `lintr::lint(…, parse_settings=TRUE)` - and we do not want to parse settings in tOAOTFSF, anyway.