### PR TITLE
Add lint-all and format-all targets to the Makefile, run format-all on lucode2 itself

### DIFF
--- a/.buildlibrary
+++ b/.buildlibrary
@@ -1,4 +1,4 @@
-ValidationKey: '83532110'
+ValidationKey: '83555802'
 AutocreateReadme: yes
 AcceptedWarnings:
 - 'Warning: package ''.*'' was built under R version'

--- a/.zenodo.json
+++ b/.zenodo.json
@@ -1,6 +1,6 @@
 {
   "title": "lucode2: Code Manipulation and Analysis Tools",
-  "version": "0.43.10",
+  "version": "0.43.11",
   "description": "<p>A collection of tools which allow to manipulate and analyze\n    code.<\/p>",
   "creators": [
     {

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Type: Package
 Package: lucode2
 Title: Code Manipulation and Analysis Tools
-Version: 0.43.10
-Date: 2023-01-24
+Version: 0.43.11
+Date: 2023-01-25
 Authors@R: c(
     person("Jan Philipp", "Dietrich", , "dietrich@pik-potsdam.de", role = c("aut", "cre")),
     person("Pascal", "Führlich", role = "aut"),

--- a/Makefile
+++ b/Makefile
@@ -22,7 +22,12 @@ test:           ## Run testthat tests
 	Rscript -e 'devtools::test(show_report = TRUE)'
 
 lint:           ## Check if code etiquette is followed using lucode2::lint()
+                ## Only checks files you changed.
 	Rscript -e 'lucode2::lint()'
+
+lint-all:       ## Check if code etiquette is followed using lucode2::lint()
+                ## Checks all files.
+	Rscript -e 'lucode2::lint(".")'
 
 format:         ## Apply auto-formatting to changed files and lint afterwards
 	Rscript -e 'lucode2::autoFormat()'

--- a/Makefile
+++ b/Makefile
@@ -32,6 +32,9 @@ lint-all:       ## Check if code etiquette is followed using lucode2::lint()
 format:         ## Apply auto-formatting to changed files and lint afterwards
 	Rscript -e 'lucode2::autoFormat()'
 
+format-all:     ## Apply auto-formatting to all files and lint afterwards
+	Rscript -e 'lucode2::autoFormat(files=list.files("./R", full.names = TRUE, pattern = "\\.R"))'
+
 install:        ## Install the package locally via devtools::install()
 	Rscript -e 'devtools::install(upgrade = "never")'
 

--- a/R/getPackageAuthors.R
+++ b/R/getPackageAuthors.R
@@ -28,11 +28,9 @@ getPackageAuthors <- function(folder = "R") {
     name <- sub(" ", "\", \"", names(ranking)[i])
     if (i == 1) {
       out <- paste0("Authors@R: c(person(\"", name, "\", email = \"@pik-potsdam.de\", role = c(\"aut\",\"cre\")),")
-    }
-    else if (i == length(ranking)) {
+    } else if (i == length(ranking)) {
       out <- c(out, paste0("             person(\"", name, "\", role = \"aut\"))"))
-    }
-    else {
+    } else {
       out <- c(out, paste0("             person(\"", name, "\", role = \"aut\"),"))
     }
   }

--- a/R/sendmail.R
+++ b/R/sendmail.R
@@ -27,7 +27,7 @@ sendmail <- function(path = NULL, gitrepo, file, commitmessage, remote = FALSE, 
   if (remote) {
     system(paste0("git -C ", path, " pull"))
   }
-  file.copy(file, paste0(path, "/README.md"), overwrite = T)
+  file.copy(file, paste0(path, "/README.md"), overwrite = TRUE)
   system(paste0("git -C ", path, " commit -m '", commitmessage, "' README.md"))
   if (remote) {
     system(paste0("git -C ", path, " push"))

--- a/R/validkey.R
+++ b/R/validkey.R
@@ -15,7 +15,7 @@ validkey <- function(package = ".", stopIfInvalid = FALSE) {
   if (!file.exists(file)) return(list(version = 0, date = 0, roxygen = FALSE, valid = FALSE))
   descfile <- readLines(file, warn = FALSE)
   .read <- function(x, y) {
-    return(sub("[^(0-9)]*$", "", sub(paste0(x, ":[^(0-9)]*"), "", grep(x, y, value = T), perl = T), perl = T))
+    return(sub("[^(0-9)]*$", "", sub(paste0(x, ":[^(0-9)]*"), "", grep(x, y, value = TRUE), perl = TRUE), perl = TRUE))
   }
   version <- .read("Version", descfile)
   date <- as.Date(.read("Date", descfile))

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Code Manipulation and Analysis Tools
 
-R package **lucode2**, version **0.43.10**
+R package **lucode2**, version **0.43.11**
 
 [![CRAN status](https://www.r-pkg.org/badges/version/lucode2)](https://cran.r-project.org/package=lucode2) [![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.4389418.svg)](https://doi.org/10.5281/zenodo.4389418) [![R build status](https://github.com/pik-piam/lucode2/workflows/check/badge.svg)](https://github.com/pik-piam/lucode2/actions) [![codecov](https://codecov.io/gh/pik-piam/lucode2/branch/master/graph/badge.svg)](https://app.codecov.io/gh/pik-piam/lucode2) [![r-universe](https://pik-piam.r-universe.dev/badges/lucode2)](https://pik-piam.r-universe.dev/ui#builds)
 
@@ -39,7 +39,7 @@ In case of questions / problems please contact Jan Philipp Dietrich <dietrich@pi
 
 To cite package **lucode2** in publications use:
 
-Dietrich J, Führlich P, Klein D, Giannousakis A, Bonsch M, Bodirsky B, Baumstark L, Richters O, Pflüger M (2023). _lucode2: Code Manipulation and Analysis Tools_. doi:10.5281/zenodo.4389418 <https://doi.org/10.5281/zenodo.4389418>, R package version 0.43.10, <https://github.com/pik-piam/lucode2>.
+Dietrich J, Führlich P, Klein D, Giannousakis A, Bonsch M, Bodirsky B, Baumstark L, Richters O, Pflüger M (2023). _lucode2: Code Manipulation and Analysis Tools_. doi:10.5281/zenodo.4389418 <https://doi.org/10.5281/zenodo.4389418>, R package version 0.43.11, <https://github.com/pik-piam/lucode2>.
 
 A BibTeX entry for LaTeX users is
 
@@ -48,7 +48,7 @@ A BibTeX entry for LaTeX users is
   title = {lucode2: Code Manipulation and Analysis Tools},
   author = {Jan Philipp Dietrich and Pascal Führlich and David Klein and Anastasis Giannousakis and Markus Bonsch and Benjamin Leon Bodirsky and Lavinia Baumstark and Oliver Richters and Mika Pflüger},
   year = {2023},
-  note = {R package version 0.43.10},
+  note = {R package version 0.43.11},
   doi = {10.5281/zenodo.4389418},
   url = {https://github.com/pik-piam/lucode2},
 }

--- a/inst/extdata/Makefile
+++ b/inst/extdata/Makefile
@@ -22,7 +22,12 @@ test:           ## Run testthat tests
 	Rscript -e 'devtools::test(show_report = TRUE)'
 
 lint:           ## Check if code etiquette is followed using lucode2::lint()
+                ## Only checks files you changed.
 	Rscript -e 'lucode2::lint()'
+
+lint-all:       ## Check if code etiquette is followed using lucode2::lint()
+                ## Checks all files.
+	Rscript -e 'lucode2::lint(".")'
 
 format:         ## Apply auto-formatting to changed files and lint afterwards
 	Rscript -e 'lucode2::autoFormat()'

--- a/inst/extdata/Makefile
+++ b/inst/extdata/Makefile
@@ -32,6 +32,9 @@ lint-all:       ## Check if code etiquette is followed using lucode2::lint()
 format:         ## Apply auto-formatting to changed files and lint afterwards
 	Rscript -e 'lucode2::autoFormat()'
 
+format-all:     ## Apply auto-formatting to all files and lint afterwards
+	Rscript -e 'lucode2::autoFormat(files=list.files("./R", full.names = TRUE, pattern = "\\.R"))'
+
 install:        ## Install the package locally via devtools::install()
 	Rscript -e 'devtools::install(upgrade = "never")'
 


### PR DESCRIPTION
Hi,

Since our goal is to make entire packages linter free and well-formatted, I added Make targets to run the linter/formatter on all files, not only changed files.

Also, I ran `format-all` on lucode2 itself, since there were still some formatting issues in older files.

Cheers,

Mika