### PR TITLE
fix fixBuildLibraryMergeConflict

### DIFF
--- a/.buildlibrary
+++ b/.buildlibrary
@@ -1,4 +1,4 @@
-ValidationKey: '83698055'
+ValidationKey: '83734716'
 AutocreateReadme: yes
 AcceptedWarnings:
 - 'Warning: package ''.*'' was built under R version'

--- a/.zenodo.json
+++ b/.zenodo.json
@@ -1,6 +1,6 @@
 {
   "title": "lucode2: Code Manipulation and Analysis Tools",
-  "version": "0.43.15",
+  "version": "0.43.16",
   "description": "<p>A collection of tools which allow to manipulate and analyze\n    code.<\/p>",
   "creators": [
     {

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Type: Package
 Package: lucode2
 Title: Code Manipulation and Analysis Tools
-Version: 0.43.15
-Date: 2023-02-09
+Version: 0.43.16
+Date: 2023-02-13
 Authors@R: c(
     person("Jan Philipp", "Dietrich", , "dietrich@pik-potsdam.de", role = c("aut", "cre")),
     person("Pascal", "Führlich", role = "aut"),

--- a/R/SystemCommandAvailable.R
+++ b/R/SystemCommandAvailable.R
@@ -8,7 +8,7 @@
 #' @examples
 #' SystemCommandAvailable("ls")
 #' @export
-SystemCommandAvailable <- function(command) {
+SystemCommandAvailable <- function(command) { # nolint: object_name_linter.
   out <- suppressWarnings(ifelse(system2(command, stdout = FALSE, stderr = FALSE) != 127, TRUE, FALSE))
   return(out)
 }

--- a/R/buildLibrary.R
+++ b/R/buildLibrary.R
@@ -94,12 +94,11 @@ buildLibrary <- function(lib = ".", cran = TRUE, updateType = NULL,
                               show = TRUE, spinner = FALSE, stdin = "")))
   }
 
-  stopifnot(`No DESCRIPTION file found` = file.exists("DESCRIPTION"))
-
-  packageName <- desc("DESCRIPTION")$get("Package")
-
   fixBuildLibraryMergeConflict()
   modifyRproj()
+
+  stopifnot(`No DESCRIPTION file found` = file.exists("DESCRIPTION"))
+  packageName <- desc("DESCRIPTION")$get("Package")
 
   ############################################################
   # load/create .buildLibrary file

--- a/R/check_versions.R
+++ b/R/check_versions.R
@@ -9,7 +9,9 @@
 #' @export
 #' @importFrom utils available.packages
 #'
-check_versions <- function(mail = TRUE, test = FALSE, gitpath = NULL) {
+check_versions <- function(mail = TRUE, # nolint: object_name_linter.
+                           test = FALSE,
+                           gitpath = NULL) {
   a <- available.packages("https://rse.pik-potsdam.de/r/packages/src/contrib")
 
   cran <- suppressWarnings(available.packages("https://cloud.r-project.org/src/contrib", filters = "duplicates"))

--- a/R/eprint_list.R
+++ b/R/eprint_list.R
@@ -14,7 +14,8 @@
 #' a <- 1:3
 #' b <- "blub"
 #' lucode2:::eprint_list(c("a", "b"))
-eprint_list <- function(var_list, envir = parent.frame()) {
+eprint_list <- function(var_list, # nolint: object_name_linter.
+                        envir = parent.frame()) {
   for (varName in var_list) {
     eprint(varName, envir = envir)
   }

--- a/R/fixBuildLibraryMergeConflict.R
+++ b/R/fixBuildLibraryMergeConflict.R
@@ -25,15 +25,20 @@ fixBuildLibraryMergeConflict <- function(lib = ".") {
   writeLines(lines, ".buildlibrary")
 
   lines <- readLines("DESCRIPTION")
-  dividerIndex <- grep("=======", lines)
   versions <- lines %>%
     grep(pattern = "^Version: (.+)$", value = TRUE) %>%
     sub(pattern = "Version: ", replacement = "") %>%
     package_version()
+
+  mergeMarkerPosition <- c(grep("<<<<<<<", lines), grep("=======", lines), grep(">>>>>>>", lines))
+  stopifnot(identical(mergeMarkerPosition, sort(mergeMarkerPosition)))
   if (versions[[1]] > versions[[2]]) {
-    lines <- lines[-c(dividerIndex - 3, dividerIndex:(dividerIndex + 3))]
+    lines <- lines[-c(mergeMarkerPosition[[1]],
+                      mergeMarkerPosition[[2]]:mergeMarkerPosition[[3]])]
   } else {
-    lines <- lines[-c((dividerIndex - 3):dividerIndex, dividerIndex + 3)]
+    lines <- lines[-c(mergeMarkerPosition[[1]]:mergeMarkerPosition[[2]],
+                      mergeMarkerPosition[[3]])]
   }
+
   writeLines(lines, "DESCRIPTION")
 }

--- a/R/lint.R
+++ b/R/lint.R
@@ -26,23 +26,23 @@ lint <- function(files = getFilesToLint()) {
   if (dir.exists(gitRoot)) {
     with_dir(gitRoot, {
       writeIfNonExistent(c("linters: lucode2::lintrRules()", 'encoding: "UTF-8"'),
-                          ".lintr")
+                         ".lintr")
       writeIfNonExistent(c("linters: lucode2::lintrRules(allowUndesirable = TRUE)", 'encoding: "UTF-8"'),
-                          file.path("tests", ".lintr", fsep = "/"))
+                         file.path("tests", ".lintr", fsep = "/"))
       writeIfNonExistent(c("linters: lucode2::lintrRules(allowUndesirable = TRUE)", 'encoding: "UTF-8"'),
-                          file.path("vignettes", ".lintr", fsep = "/"))
+                         file.path("vignettes", ".lintr", fsep = "/"))
     })
   }
 
   if (identical(files, ".")) {
-    return(lint_package())
+    files <- list.files(pattern = "[.]R(md)?$", full.names = TRUE, recursive = TRUE)
   }
 
   files <- normalizePath(files)
 
-  linterWarnings <- lapply(files, function(aFile) {
-    message('Running lintr::lint("', aFile, '")')
-    return(lintr::lint(aFile))
+  linterWarnings <- lapply(seq_along(files), function(i) {
+    message("[", i, "/", length(files), '] Running lintr::lint("', files[[i]], '")')
+    return(lintr::lint(files[[i]]))
   })
 
   # combine the results of multiple calls to lintr::lint, taken from lintr:::flatten_lints

--- a/R/lint.R
+++ b/R/lint.R
@@ -41,7 +41,10 @@ lint <- function(files = getFilesToLint()) {
   files <- normalizePath(files)
 
   linterWarnings <- lapply(seq_along(files), function(i) {
-    message("[", i, "/", length(files), '] Running lintr::lint("', files[[i]], '")')
+    if (length(files) > 1) {
+      message("[", i, "/", length(files), "] ", appendLF = FALSE)
+    }
+    message('Running lintr::lint("', files[[i]], '")')
     return(lintr::lint(files[[i]]))
   })
 

--- a/R/memCheck.R
+++ b/R/memCheck.R
@@ -22,26 +22,27 @@
 #' }
 #' @importFrom utils capture.output object.size head
 #' @export
-memCheck <- function(order.by = "Size", decreasing = TRUE, n = NULL, envir = parent.frame(), gc = TRUE) {
-  napply <- function(names, fn, pos) sapply(names, function(x)
-    fn(get(x, pos = pos)))
+memCheck <- function(order.by = "Size", # nolint: object_name_linter.
+                     decreasing = TRUE, n = NULL, envir = parent.frame(), gc = TRUE) {
+  napply <- function(names, fn, pos) {
+    sapply(names, function(x) fn(get(x, pos = pos))) # nolint: undesirable_function_linter.
+  }
   names <- ls(envir)
   if (length(names) == 0) {
     cat("\nEnvironment is empty!\n")
     return(NULL)
   }
-  obj.class <- napply(names, function(x) as.character(class(x))[1], envir)
-  obj.mode <- napply(names, mode, envir)
-  obj.type <- ifelse(is.na(obj.class), obj.mode, obj.class)
-  obj.prettysize <- napply(names, function(x) {
+  objClass <- napply(names, function(x) as.character(class(x))[1], envir)
+  objMode <- napply(names, mode, envir)
+  objType <- ifelse(is.na(objClass), objMode, objClass)
+  objPrettysize <- napply(names, function(x) {
     capture.output(print(object.size(x), units = "auto"))
   }, envir)
-  obj.size <- napply(names, object.size, envir)
-  obj.dim <- t(napply(names, function(x)
-    as.numeric(dim(x))[1:2], envir))
-  vec <- is.na(obj.dim)[, 1] & (obj.type != "function")
-  obj.dim[vec, 1] <- napply(names, length, envir)[vec]
-  out <- data.frame(obj.type, obj.size, obj.prettysize, obj.dim)
+  objSize <- napply(names, object.size, envir)
+  objDim <- t(napply(names, function(x) as.numeric(dim(x))[1:2], envir))
+  vec <- is.na(objDim)[, 1] & (objType != "function")
+  objDim[vec, 1] <- napply(names, length, envir)[vec]
+  out <- data.frame(objType, objSize, objPrettysize, objDim)
   names(out) <- c("Type", "Size", "PrettySize", "Rows", "Columns")
   if (!is.null(order.by))
     out <- out[order(out[[order.by]], decreasing = decreasing), ]

--- a/R/mergestatistics.R
+++ b/R/mergestatistics.R
@@ -29,7 +29,7 @@ mergestatistics <- function(dir = ".", file = NULL, renew = FALSE, quickcheck = 
   }
   out <- NULL
   id  <- NULL
-  if (!is.null(file) & !renew) {
+  if (!is.null(file) && !renew) {
     if (file.exists(file)) {
       out <- readRDS(file)
     }

--- a/R/readRuntime.R
+++ b/R/readRuntime.R
@@ -57,14 +57,14 @@ readRuntime <- function(path, plot = FALSE, types = NULL, coupled = FALSE, outfn
       stats <- NULL
       load(datafile)
       # try to load detailed runtime information
-      if (!is.null(stats) & !is.null(stats$timePrepareStart)) {
+      if (!is.null(stats) && !is.null(stats$timePrepareStart)) {
         timePrepareStart <- stats$timePrepareStart
         timePrepareEnd   <- stats$timePrepareEnd
         timeGAMSStart    <- stats$timeGAMSStart
         timeGAMSEnd      <- stats$timeGAMSEnd
         timeOutputStart  <- stats$timeOutputStart
         timeOutputEnd    <- stats$timeOutputEnd
-      } else if (!is.null(stats) & !is.null(stats$starttime)) {
+      } else if (!is.null(stats) && !is.null(stats$starttime)) {
         # if no detailed information is available load the old one (it's only the gams runtime)
         start <- stats$starttime
         end   <- stats$endtime
@@ -73,7 +73,7 @@ readRuntime <- function(path, plot = FALSE, types = NULL, coupled = FALSE, outfn
 
     # if no start and end was extractable from runstatistics.rda
     # conclude it from timestamps of the files in the results folder
-    if (is.null(end) & is.null(timePrepareEnd) & is.null(timeGAMSEnd) & is.null(timeOutputEnd)) {
+    if (is.null(end) && is.null(timePrepareEnd) && is.null(timeGAMSEnd) && is.null(timeOutputEnd)) {
       local_dir(d)
       # find all files
       info <- file.info(dir())

--- a/R/rmAllbut.R
+++ b/R/rmAllbut.R
@@ -31,7 +31,7 @@ rmAllbut <- function(..., list = character(), clean = TRUE) {
   keepObjects[[1]] <- NULL
   keepObjects <- lapply(keepObjects, as.character)
   if (!is.null(list)) {
-    if (all(sapply(list, is.character))) {
+    if (all(vapply(list, is.character, logical(1)))) {
       keepObjects <- append(keepObjects, list)
     } else {
       stop("list argument can only contain characters")

--- a/R/runstatistics.R
+++ b/R/runstatistics.R
@@ -24,7 +24,7 @@ runstatistics <- function(file = "runstatistics.Rda", overwrite = TRUE, submit =
   if (file.exists(file)) load(file)
 
   overlap <- intersect(names(x), names(stats))
-  if (length(overlap) > 0 & !overwrite) {
+  if (length(overlap) > 0 && !overwrite) {
     stop("Attempt to overwrite the following entries with overwrite=FALSE: ", paste(overlap, collapse = ", "))
   }
   stats[names(x)] <- x[names(x)]

--- a/R/setup_info.R
+++ b/R/setup_info.R
@@ -11,7 +11,7 @@
 #' @examples
 #'
 #' setup_info()
-setup_info <- function() {
+setup_info <- function() { # nolint: object_name_linter.
   out <- list()
   out$sysinfo <- Sys.info()
   out$sessionInfo <- sessionInfo()

--- a/R/variableLinks.R
+++ b/R/variableLinks.R
@@ -1,4 +1,4 @@
 variableLinks <- function(x, name) {
-  tmp <- sapply(x, function(x, y) return(y %in% x), name)
+  tmp <- sapply(x, function(x, y) return(y %in% x), name) # nolint
   return(names(tmp)[tmp])
 }

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Code Manipulation and Analysis Tools
 
-R package **lucode2**, version **0.43.15**
+R package **lucode2**, version **0.43.16**
 
 [![CRAN status](https://www.r-pkg.org/badges/version/lucode2)](https://cran.r-project.org/package=lucode2) [![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.4389418.svg)](https://doi.org/10.5281/zenodo.4389418) [![R build status](https://github.com/pik-piam/lucode2/workflows/check/badge.svg)](https://github.com/pik-piam/lucode2/actions) [![codecov](https://codecov.io/gh/pik-piam/lucode2/branch/master/graph/badge.svg)](https://app.codecov.io/gh/pik-piam/lucode2) [![r-universe](https://pik-piam.r-universe.dev/badges/lucode2)](https://pik-piam.r-universe.dev/builds)
 
@@ -39,7 +39,7 @@ In case of questions / problems please contact Jan Philipp Dietrich <dietrich@pi
 
 To cite package **lucode2** in publications use:
 
-Dietrich J, Führlich P, Klein D, Giannousakis A, Bonsch M, Bodirsky B, Baumstark L, Richters O, Pflüger M (2023). _lucode2: Code Manipulation and Analysis Tools_. doi:10.5281/zenodo.4389418 <https://doi.org/10.5281/zenodo.4389418>, R package version 0.43.15, <https://github.com/pik-piam/lucode2>.
+Dietrich J, Führlich P, Klein D, Giannousakis A, Bonsch M, Bodirsky B, Baumstark L, Richters O, Pflüger M (2023). _lucode2: Code Manipulation and Analysis Tools_. doi:10.5281/zenodo.4389418 <https://doi.org/10.5281/zenodo.4389418>, R package version 0.43.16, <https://github.com/pik-piam/lucode2>.
 
 A BibTeX entry for LaTeX users is
 
@@ -48,7 +48,7 @@ A BibTeX entry for LaTeX users is
   title = {lucode2: Code Manipulation and Analysis Tools},
   author = {Jan Philipp Dietrich and Pascal Führlich and David Klein and Anastasis Giannousakis and Markus Bonsch and Benjamin Leon Bodirsky and Lavinia Baumstark and Oliver Richters and Mika Pflüger},
   year = {2023},
-  note = {R package version 0.43.15},
+  note = {R package version 0.43.16},
   doi = {10.5281/zenodo.4389418},
   url = {https://github.com/pik-piam/lucode2},
 }

--- a/tests/testthat/test-fixBuildLibraryMergeConflict.R
+++ b/tests/testthat/test-fixBuildLibraryMergeConflict.R
@@ -61,4 +61,34 @@ test_that("fixBuildLibraryMergeConflict works", {
                      "Title: May All Data be Reproducible and Transparent (MADRaT) *",
                      "Version: 2.14.4",
                      "Date: 2022-03-08"))
+
+  writeLines(c("<<<<<<< HEAD",
+               "ValidationKey: '40481316'",
+               "=======",
+               "ValidationKey: '40597800'",
+               ">>>>>>> a1cb66cbf5f9ed75e57271542662266ac63841d7",
+               "AcceptedWarnings:",
+               "- 'Warning: package ''.*'' was built under R version'"),
+             file.path(tempFolder, ".buildlibrary"))
+  writeLines(c("Package: madrat",
+               "Type: Package",
+               "Title: May All Data be Reproducible and Transparent (MADRaT) *",
+               "<<<<<<< HEAD",
+               "Version: 2.14.4",
+               "pusteblume",
+               "=======",
+               "Version: 2.13.0",
+               ">>>>>>> a1cb66cbf5f9ed75e57271542662266ac63841d7",
+               "Date: 2022-03-09"),
+             file.path(tempFolder, "DESCRIPTION"))
+
+  fixBuildLibraryMergeConflict(tempFolder)
+
+  expect_identical(readLines(file.path(tempFolder, "DESCRIPTION")),
+                   c("Package: madrat",
+                     "Type: Package",
+                     "Title: May All Data be Reproducible and Transparent (MADRaT) *",
+                     "Version: 2.14.4",
+                     "pusteblume",
+                     "Date: 2022-03-09"))
 })


### PR DESCRIPTION
this PR adresses a couple of problems:
- fixBuildLibraryMergeConflict was called in buildLibrary after trying to read the DESCRIPTION which failed because of git merge markers in DESCRIPTION
- fixBuildLibraryMergeConflict was assuming a conflict of two lines in DESCRIPTION (version and date), although date is sometimes not part of the conflict
- the lint package feature (`lucode2::lint(".")`) was not applying the less strict linter rules to tests