### PR TITLE
require lintr 3.1.0

### DIFF
--- a/.buildlibrary
+++ b/.buildlibrary
@@ -1,4 +1,4 @@
-ValidationKey: '8771392'
+ValidationKey: '8808931'
 AutocreateReadme: yes
 AcceptedWarnings:
 - 'Warning: package ''.*'' was built under R version'

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -2,8 +2,8 @@ cff-version: 1.2.0
 message: If you use this software, please cite it using the metadata from this file.
 type: software
 title: 'lucode2: Code Manipulation and Analysis Tools'
-version: 0.44.8
-date-released: '2023-08-10'
+version: 0.44.9
+date-released: '2023-09-19'
 abstract: A collection of tools which allow to manipulate and analyze code.
 authors:
 - family-names: Dietrich

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Type: Package
 Package: lucode2
 Title: Code Manipulation and Analysis Tools
-Version: 0.44.8
-Date: 2023-08-10
+Version: 0.44.9
+Date: 2023-09-19
 Authors@R: c(
     person("Jan Philipp", "Dietrich", , "dietrich@pik-potsdam.de", role = c("aut", "cre")),
     person("Pascal", "Führlich", role = "aut"),
@@ -27,7 +27,7 @@ Imports:
     desc,
     devtools,
     dplyr,
-    lintr (>= 3.0.0),
+    lintr (>= 3.1.0),
     rlang,
     tools,
     usethis (>= 2.1.0),

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Code Manipulation and Analysis Tools
 
-R package **lucode2**, version **0.44.8**
+R package **lucode2**, version **0.44.9**
 
 [![CRAN status](https://www.r-pkg.org/badges/version/lucode2)](https://cran.r-project.org/package=lucode2) [![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.4389418.svg)](https://doi.org/10.5281/zenodo.4389418) [![R build status](https://github.com/pik-piam/lucode2/workflows/check/badge.svg)](https://github.com/pik-piam/lucode2/actions) [![codecov](https://codecov.io/gh/pik-piam/lucode2/branch/master/graph/badge.svg)](https://app.codecov.io/gh/pik-piam/lucode2) [![r-universe](https://pik-piam.r-universe.dev/badges/lucode2)](https://pik-piam.r-universe.dev/builds)
 
@@ -39,7 +39,7 @@ In case of questions / problems please contact Jan Philipp Dietrich <dietrich@pi
 
 To cite package **lucode2** in publications use:
 
-Dietrich J, Führlich P, Klein D, Giannousakis A, Bonsch M, Bodirsky B, Baumstark L, Richters O, Pflüger M (2023). _lucode2: Code Manipulation and Analysis Tools_. doi:10.5281/zenodo.4389418 <https://doi.org/10.5281/zenodo.4389418>, R package version 0.44.8, <https://github.com/pik-piam/lucode2>.
+Dietrich J, Führlich P, Klein D, Giannousakis A, Bonsch M, Bodirsky B, Baumstark L, Richters O, Pflüger M (2023). _lucode2: Code Manipulation and Analysis Tools_. doi: 10.5281/zenodo.4389418 (URL: https://doi.org/10.5281/zenodo.4389418), R package version 0.44.9, <URL: https://github.com/pik-piam/lucode2>.
 
 A BibTeX entry for LaTeX users is
 
@@ -48,7 +48,7 @@ A BibTeX entry for LaTeX users is
   title = {lucode2: Code Manipulation and Analysis Tools},
   author = {Jan Philipp Dietrich and Pascal Führlich and David Klein and Anastasis Giannousakis and Markus Bonsch and Benjamin Leon Bodirsky and Lavinia Baumstark and Oliver Richters and Mika Pflüger},
   year = {2023},
-  note = {R package version 0.44.8},
+  note = {R package version 0.44.9},
   doi = {10.5281/zenodo.4389418},
   url = {https://github.com/pik-piam/lucode2},
 }


### PR DESCRIPTION
- the quitte package uses lintr methods that are only in 3.1.0, so make sure you have an updated version to avoid that buildLibrary fails