### PR TITLE
use usethis::use_package_doc

### DIFF
--- a/.buildlibrary
+++ b/.buildlibrary
@@ -1,4 +1,4 @@
-ValidationKey: '9067520'
+ValidationKey: '9099218'
 AutocreateReadme: yes
 AcceptedWarnings:
 - 'Warning: package ''.*'' was built under R version'

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -2,8 +2,8 @@ cff-version: 1.2.0
 message: If you use this software, please cite it using the metadata from this file.
 type: software
 title: 'lucode2: Code Manipulation and Analysis Tools'
-version: 0.46.0
-date-released: '2023-12-21'
+version: 0.46.1
+date-released: '2024-01-16'
 abstract: A collection of tools which allow to manipulate and analyze code.
 authors:
 - family-names: Dietrich

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Type: Package
 Package: lucode2
 Title: Code Manipulation and Analysis Tools
-Version: 0.46.0
-Date: 2023-12-21
+Version: 0.46.1
+Date: 2024-01-16
 Authors@R: c(
     person("Jan Philipp", "Dietrich", , "dietrich@pik-potsdam.de", role = c("aut", "cre")),
     person("Pascal", "Sauer", role = "aut"),
@@ -49,7 +49,7 @@ Suggests:
     testthat
 Encoding: UTF-8
 LazyData: no
-RoxygenNote: 7.2.3
+RoxygenNote: 7.3.0
 Config/testthat/parallel: true
 Config/testthat/edition: 3
 Config/testthat/start-first: checkRequiredPackages, updateRepo

--- a/R/check.R
+++ b/R/check.R
@@ -34,10 +34,7 @@ check <- function(lib = ".", cran = TRUE, config = loadBuildLibraryConfig(lib), 
 
   packageDocumentation <- file.path("R", paste0(packageName, "-package.R"))
   if (!file.exists(packageDocumentation) && !file.exists(file.path("R", paste0(packageName, ".R")))) {
-    writeLines(c("# The package documentation is defined in this file.",
-                 "# You can get it via `library(<package>); ?<package>`.",
-                 "#' @docType package",
-                 '"_PACKAGE"'), packageDocumentation)
+    usethis::use_package_doc(open = FALSE)
   }
 
   document(pkg = ".", roclets = c("rd", "collate", "namespace", "vignette"))

--- a/R/lucode2-package.R
+++ b/R/lucode2-package.R
@@ -1,4 +1,6 @@
-# The package documentation is defined in this file.
-# You can get it via `library(<package>); ?<package>`.
-#' @docType package
+#' @keywords internal
 "_PACKAGE"
+
+## usethis namespace: start
+## usethis namespace: end
+NULL

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Code Manipulation and Analysis Tools
 
-R package **lucode2**, version **0.46.0**
+R package **lucode2**, version **0.46.1**
 
 [![CRAN status](https://www.r-pkg.org/badges/version/lucode2)](https://cran.r-project.org/package=lucode2) [![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.4389418.svg)](https://doi.org/10.5281/zenodo.4389418) [![R build status](https://github.com/pik-piam/lucode2/workflows/check/badge.svg)](https://github.com/pik-piam/lucode2/actions) [![codecov](https://codecov.io/gh/pik-piam/lucode2/branch/master/graph/badge.svg)](https://app.codecov.io/gh/pik-piam/lucode2) [![r-universe](https://pik-piam.r-universe.dev/badges/lucode2)](https://pik-piam.r-universe.dev/builds)
 
@@ -39,7 +39,7 @@ In case of questions / problems please contact Jan Philipp Dietrich <dietrich@pi
 
 To cite package **lucode2** in publications use:
 
-Dietrich J, Sauer P, Klein D, Giannousakis A, Bonsch M, Bodirsky B, Baumstark L, Richters O, Pflüger M (2023). _lucode2: Code Manipulation and Analysis Tools_. doi: 10.5281/zenodo.4389418 (URL: https://doi.org/10.5281/zenodo.4389418), R package version 0.46.0, <URL: https://github.com/pik-piam/lucode2>.
+Dietrich J, Sauer P, Klein D, Giannousakis A, Bonsch M, Bodirsky B, Baumstark L, Richters O, Pflüger M (2024). _lucode2: Code Manipulation and Analysis Tools_. doi:10.5281/zenodo.4389418 <https://doi.org/10.5281/zenodo.4389418>, R package version 0.46.1, <https://github.com/pik-piam/lucode2>.
 
 A BibTeX entry for LaTeX users is
 
@@ -47,9 +47,9 @@ A BibTeX entry for LaTeX users is
 @Manual{,
   title = {lucode2: Code Manipulation and Analysis Tools},
   author = {Jan Philipp Dietrich and Pascal Sauer and David Klein and Anastasis Giannousakis and Markus Bonsch and Benjamin Leon Bodirsky and Lavinia Baumstark and Oliver Richters and Mika Pflüger},
-  year = {2023},
-  note = {R package version 0.46.0},
-  doi = {10.5281/zenodo.4389418},
+  year = {2024},
+  note = {R package version 0.46.1},
   url = {https://github.com/pik-piam/lucode2},
+  doi = {10.5281/zenodo.4389418},
 }
 ```

--- a/man/lucode2-package.Rd
+++ b/man/lucode2-package.Rd
@@ -33,3 +33,4 @@ Authors:
 }
 
 }
+\keyword{internal}


### PR DESCRIPTION
This will prevent the deprecation warning for `@docType package` for packages which do not have a `R/<package-name>-package.R` file yet. Packages where this file already exists have to be fixed manually, usually by deleting `@docType package` and replacing the documented object `NULL` with `"_PACKAGE"` as was done in https://github.com/pik-piam/mrland/commit/7cf0b23b990c1a0512fac4f24d124377a74d4ada