### PR TITLE
add isVersionUpdated to check workflow

### DIFF
--- a/.buildlibrary
+++ b/.buildlibrary
@@ -1,4 +1,4 @@
-ValidationKey: '9151195'
+ValidationKey: '9290490'
 AutocreateReadme: yes
 AcceptedWarnings:
 - 'Warning: package ''.*'' was built under R version'

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -2,8 +2,8 @@ cff-version: 1.2.0
 message: If you use this software, please cite it using the metadata from this file.
 type: software
 title: 'lucode2: Code Manipulation and Analysis Tools'
-version: 0.46.3
-date-released: '2024-02-12'
+version: 0.47.0
+date-released: '2024-02-14'
 abstract: A collection of tools which allow to manipulate and analyze code.
 authors:
 - family-names: Dietrich

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Type: Package
 Package: lucode2
 Title: Code Manipulation and Analysis Tools
-Version: 0.46.3
-Date: 2024-02-12
+Version: 0.47.0
+Date: 2024-02-14
 Authors@R: c(
     person("Jan Philipp", "Dietrich", , "dietrich@pik-potsdam.de", role = c("aut", "cre")),
     person("Pascal", "Sauer", role = "aut"),

--- a/R/isVersionUpdated.R
+++ b/R/isVersionUpdated.R
@@ -3,12 +3,14 @@
 #' Checks if the version number in the DESCRIPTION file of a given package has
 #' been updated.
 #' @param repo package repository to determine latest version
+#' @param config A configuration defining enforceVersionUpdate. By default
+#' the .buildLibrary file is read.
 #' @importFrom desc desc
 #' @importFrom utils packageVersion
 #' @author Falk Benke
 #' @export
-isVersionUpdated <- function(repo = "https://rse.pik-potsdam.de/r/packages/") {
-
+isVersionUpdated <- function(repo = "https://rse.pik-potsdam.de/r/packages/",
+                             config = loadBuildLibraryConfig()) {
   if (!file.exists("DESCRIPTION")) stop("No DESCRIPTION file found")
 
   env <- desc("DESCRIPTION")
@@ -24,6 +26,10 @@ isVersionUpdated <- function(repo = "https://rse.pik-potsdam.de/r/packages/") {
   latestVersion <- package_version(version)
 
   if (thisVersion <= latestVersion) {
-    stop(paste0("Version has not been updated. Did you run lucode2::buildLibrary()?\n Latest: ", latestVersion))
+    msg <- paste0("Version has not been updated. Did you run lucode2::buildLibrary()?\n Latest: ",
+                  latestVersion, ". Local: ", thisVersion)
+
+    if (config[["enforceVersionUpdate"]]) stop(msg) else warning(msg)
+
   }
 }

--- a/R/loadBuildLibraryConfig.R
+++ b/R/loadBuildLibraryConfig.R
@@ -57,5 +57,9 @@ loadBuildLibraryConfig <- function(lib = ".") {
     cfg$allowLinterWarnings <- TRUE
   }
 
+  if (is.null(cfg$enforceVersionUpdate)) {
+    cfg$enforceVersionUpdate <- FALSE
+  }
+
   return(cfg)
 }

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Code Manipulation and Analysis Tools
 
-R package **lucode2**, version **0.46.3**
+R package **lucode2**, version **0.47.0**
 
 [![CRAN status](https://www.r-pkg.org/badges/version/lucode2)](https://cran.r-project.org/package=lucode2) [![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.4389418.svg)](https://doi.org/10.5281/zenodo.4389418) [![R build status](https://github.com/pik-piam/lucode2/workflows/check/badge.svg)](https://github.com/pik-piam/lucode2/actions) [![codecov](https://codecov.io/gh/pik-piam/lucode2/branch/master/graph/badge.svg)](https://app.codecov.io/gh/pik-piam/lucode2) [![r-universe](https://pik-piam.r-universe.dev/badges/lucode2)](https://pik-piam.r-universe.dev/builds)
 
@@ -39,7 +39,7 @@ In case of questions / problems please contact Jan Philipp Dietrich <dietrich@pi
 
 To cite package **lucode2** in publications use:
 
-Dietrich J, Sauer P, Klein D, Giannousakis A, Bonsch M, Bodirsky B, Baumstark L, Richters O, Pflüger M (2024). _lucode2: Code Manipulation and Analysis Tools_. doi: 10.5281/zenodo.4389418 (URL: https://doi.org/10.5281/zenodo.4389418), R package version 0.46.3, <URL: https://github.com/pik-piam/lucode2>.
+Dietrich J, Sauer P, Klein D, Giannousakis A, Bonsch M, Bodirsky B, Baumstark L, Richters O, Pflüger M (2024). _lucode2: Code Manipulation and Analysis Tools_. doi:10.5281/zenodo.4389418 <https://doi.org/10.5281/zenodo.4389418>, R package version 0.47.0, <https://github.com/pik-piam/lucode2>.
 
 A BibTeX entry for LaTeX users is
 
@@ -48,7 +48,7 @@ A BibTeX entry for LaTeX users is
   title = {lucode2: Code Manipulation and Analysis Tools},
   author = {Jan Philipp Dietrich and Pascal Sauer and David Klein and Anastasis Giannousakis and Markus Bonsch and Benjamin Leon Bodirsky and Lavinia Baumstark and Oliver Richters and Mika Pflüger},
   year = {2024},
-  note = {R package version 0.46.3},
+  note = {R package version 0.47.0},
   doi = {10.5281/zenodo.4389418},
   url = {https://github.com/pik-piam/lucode2},
 }

--- a/inst/extdata/check.yaml
+++ b/inst/extdata/check.yaml
@@ -49,6 +49,11 @@ jobs:
         shell: Rscript {0}
         run: lucode2:::validkey(stopIfInvalid = TRUE)
 
+      - name: Verify that lucode2::buildLibrary was successful
+        if: github.event_name == 'pull_request'
+        shell: Rscript {0}
+        run: lucode2:::isVersionUpdated()
+
       - name: Checks
         shell: Rscript {0}
         run: |

--- a/man/isVersionUpdated.Rd
+++ b/man/isVersionUpdated.Rd
@@ -4,10 +4,16 @@
 \alias{isVersionUpdated}
 \title{isVersionUpdated}
 \usage{
-isVersionUpdated(repo = "https://rse.pik-potsdam.de/r/packages/")
+isVersionUpdated(
+  repo = "https://rse.pik-potsdam.de/r/packages/",
+  config = loadBuildLibraryConfig()
+)
 }
 \arguments{
 \item{repo}{package repository to determine latest version}
+
+\item{config}{A configuration defining enforceVersionUpdate. By default
+the .buildLibrary file is read.}
 }
 \description{
 Checks if the version number in the DESCRIPTION file of a given package has


### PR DESCRIPTION
Adds `isVersionUpdated` as a check to the Github workflow `check`. Produces a warning by default, if version has not been incremented. Setting `enforceVersionUpdate: yes` turns it into an error.  The check only runs on pull requests.