### PR TITLE
handle package not found on RSE server in isVersionUpdated

### DIFF
--- a/.buildlibrary
+++ b/.buildlibrary
@@ -1,4 +1,4 @@
-ValidationKey: '9322974'
+ValidationKey: '9347016'
 AutocreateReadme: yes
 AcceptedWarnings:
 - 'Warning: package ''.*'' was built under R version'

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -2,8 +2,8 @@ cff-version: 1.2.0
 message: If you use this software, please cite it using the metadata from this file.
 type: software
 title: 'lucode2: Code Manipulation and Analysis Tools'
-version: 0.47.1
-date-released: '2024-03-12'
+version: 0.47.2
+date-released: '2024-03-21'
 abstract: A collection of tools which allow to manipulate and analyze code.
 authors:
 - family-names: Dietrich

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Type: Package
 Package: lucode2
 Title: Code Manipulation and Analysis Tools
-Version: 0.47.1
-Date: 2024-03-12
+Version: 0.47.2
+Date: 2024-03-21
 Authors@R: c(
     person("Jan Philipp", "Dietrich", , "dietrich@pik-potsdam.de", role = c("aut", "cre")),
     person("Pascal", "Sauer", role = "aut"),

--- a/R/isVersionUpdated.R
+++ b/R/isVersionUpdated.R
@@ -28,13 +28,19 @@ isVersionUpdated <- function(repo = "https://rse.pik-potsdam.de/r/packages/",
       if (config[["enforceVersionUpdate"]]) stop("Failed to retrieve latest version of this package.") else return()
     }
   )
+
+  if (is.null(version)) {
+    if (config[["enforceVersionUpdate"]]) stop("Package not found on RSE server.") else return()
+  }
+
   latestVersion <- package_version(version)
 
   if (thisVersion <= latestVersion) {
-    msg <- paste0("Version has not been updated. Did you run lucode2::buildLibrary()?\n Latest: ",
-                  latestVersion, ". Local: ", thisVersion)
+    msg <- paste0(
+      "Version has not been updated. Did you run lucode2::buildLibrary()?\n Latest: ",
+      latestVersion, ". Local: ", thisVersion
+    )
 
     if (config[["enforceVersionUpdate"]]) stop(msg) else warning(msg)
-
   }
 }

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Code Manipulation and Analysis Tools
 
-R package **lucode2**, version **0.47.1**
+R package **lucode2**, version **0.47.2**
 
 [![CRAN status](https://www.r-pkg.org/badges/version/lucode2)](https://cran.r-project.org/package=lucode2) [![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.4389418.svg)](https://doi.org/10.5281/zenodo.4389418) [![R build status](https://github.com/pik-piam/lucode2/workflows/check/badge.svg)](https://github.com/pik-piam/lucode2/actions) [![codecov](https://codecov.io/gh/pik-piam/lucode2/branch/master/graph/badge.svg)](https://app.codecov.io/gh/pik-piam/lucode2) [![r-universe](https://pik-piam.r-universe.dev/badges/lucode2)](https://pik-piam.r-universe.dev/builds)
 
@@ -39,7 +39,7 @@ In case of questions / problems please contact Jan Philipp Dietrich <dietrich@pi
 
 To cite package **lucode2** in publications use:
 
-Dietrich J, Sauer P, Klein D, Giannousakis A, Bonsch M, Bodirsky B, Baumstark L, Richters O, Pflüger M (2024). _lucode2: Code Manipulation and Analysis Tools_. doi:10.5281/zenodo.4389418 <https://doi.org/10.5281/zenodo.4389418>, R package version 0.47.1, <https://github.com/pik-piam/lucode2>.
+Dietrich J, Sauer P, Klein D, Giannousakis A, Bonsch M, Bodirsky B, Baumstark L, Richters O, Pflüger M (2024). _lucode2: Code Manipulation and Analysis Tools_. doi:10.5281/zenodo.4389418 <https://doi.org/10.5281/zenodo.4389418>, R package version 0.47.2, <https://github.com/pik-piam/lucode2>.
 
 A BibTeX entry for LaTeX users is
 
@@ -48,7 +48,7 @@ A BibTeX entry for LaTeX users is
   title = {lucode2: Code Manipulation and Analysis Tools},
   author = {Jan Philipp Dietrich and Pascal Sauer and David Klein and Anastasis Giannousakis and Markus Bonsch and Benjamin Leon Bodirsky and Lavinia Baumstark and Oliver Richters and Mika Pflüger},
   year = {2024},
-  note = {R package version 0.47.1},
+  note = {R package version 0.47.2},
   doi = {10.5281/zenodo.4389418},
   url = {https://github.com/pik-piam/lucode2},
 }


### PR DESCRIPTION
This fix avoids errors in isVersionUpdated when a package is not found on RSE server.
 
Currently, there is a problem when a new package needs to pass buildLibrary in order to be published on the RSE server, but in order to pass the check, the reference version is expected from the RSE server.