### PR TITLE
adjust variable = value regexp in manipulateConfig to avoid false positives in comments

### DIFF
--- a/.buildlibrary
+++ b/.buildlibrary
@@ -1,4 +1,4 @@
-ValidationKey: '9512678'
+ValidationKey: '9551739'
 AutocreateReadme: yes
 AcceptedWarnings:
 - 'Warning: package ''.*'' was built under R version'

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -2,8 +2,8 @@ cff-version: 1.2.0
 message: If you use this software, please cite it using the metadata from this file.
 type: software
 title: 'lucode2: Code Manipulation and Analysis Tools'
-version: 0.47.8
-date-released: '2024-06-27'
+version: 0.47.9
+date-released: '2024-08-06'
 abstract: A collection of tools which allow to manipulate and analyze code.
 authors:
 - family-names: Dietrich

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Type: Package
 Package: lucode2
 Title: Code Manipulation and Analysis Tools
-Version: 0.47.8
-Date: 2024-06-27
+Version: 0.47.9
+Date: 2024-08-06
 Authors@R: c(
     person("Jan Philipp", "Dietrich", email = "dietrich@pik-potsdam.de", 
     comment = c(affiliation = "Potsdam Institute for Climate Impact Research", ORCID = "0000-0002-4309-6431"), role = c("aut","cre")),
@@ -50,7 +50,7 @@ Suggests:
     testthat
 Encoding: UTF-8
 LazyData: no
-RoxygenNote: 7.3.1
+RoxygenNote: 7.3.2
 Config/testthat/parallel: true
 Config/testthat/edition: 3
 Config/testthat/start-first: checkRequiredPackages, updateRepo

--- a/R/manipulateConfig.R
+++ b/R/manipulateConfig.R
@@ -47,7 +47,7 @@ manipulateConfig <- function(configFile, ...) {
                                                        i, "(|\\([^\\)]*\\))(/|[\\t ]+(\"[^\"]*\"|)[^\"/;]*/))[^/]*",
                                                        sep = "")
       m[[paste(i, "_pattern2", sep = "")]][2] <- paste("\\1 ", rpl, " ", sep = "")
-      m[[paste(i, "_pattern3", sep = "")]][1] <- paste("((^|[\\n\\t ])", i, "[ \\t]*=[ \\t]*[\"\']?)[^\"\';]*",
+      m[[paste(i, "_pattern3", sep = "")]][1] <- paste("((^|\\n)[ \\t]*", i, "[ \\t]*=[ \\t]*[\"\']?)[^\"\';]*",
                                                        sep = "")
       m[[paste(i, "_pattern3", sep = "")]][2] <- paste("\\1", rpl, sep = "")
     }

--- a/R/manipulateConfig.R
+++ b/R/manipulateConfig.R
@@ -41,8 +41,8 @@ manipulateConfig <- function(configFile, ...) {
       }
 
       m[[paste(i, "_pattern1", sep = "")]][1] <- paste("(\\$[sS][eE][tT][gG][lL][oO][bB][aA][lL][\\t ]*",
-                                                       i, "[\\t ]).*?( *!!|\\n|$)", sep = "")
-      m[[paste(i, "_pattern1", sep = "")]][2] <- paste("\\1 ", rpl, "\\2", sep = "")
+                                                       i, "[\\t ]+).*?( *!!|\\n|$)", sep = "")
+      m[[paste(i, "_pattern1", sep = "")]][2] <- paste("\\1", rpl, "\\2", sep = "")
       m[[paste(i, "_pattern2", sep = "")]][1] <- paste("((\\n|^)[\\t ]*(scalar|parameter|set|)s?[\\t ]*",
                                                        i, "(|\\([^\\)]*\\))(/|[\\t ]+(\"[^\"]*\"|)[^\"/;]*/))[^/]*",
                                                        sep = "")

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Code Manipulation and Analysis Tools
 
-R package **lucode2**, version **0.47.8**
+R package **lucode2**, version **0.47.9**
 
 [![CRAN status](https://www.r-pkg.org/badges/version/lucode2)](https://cran.r-project.org/package=lucode2) [![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.4389418.svg)](https://doi.org/10.5281/zenodo.4389418) [![R build status](https://github.com/pik-piam/lucode2/workflows/check/badge.svg)](https://github.com/pik-piam/lucode2/actions) [![codecov](https://codecov.io/gh/pik-piam/lucode2/branch/master/graph/badge.svg)](https://app.codecov.io/gh/pik-piam/lucode2) [![r-universe](https://pik-piam.r-universe.dev/badges/lucode2)](https://pik-piam.r-universe.dev/builds)
 
@@ -39,7 +39,7 @@ In case of questions / problems please contact Jan Philipp Dietrich <dietrich@pi
 
 To cite package **lucode2** in publications use:
 
-Dietrich J, Sauer P, Klein D, Giannousakis A, Bonsch M, Bodirsky B, Baumstark L, Richters O, Pflüger M (2024). _lucode2: Code Manipulation and Analysis Tools_. doi: 10.5281/zenodo.4389418 (URL: https://doi.org/10.5281/zenodo.4389418), R package version 0.47.8, <URL: https://github.com/pik-piam/lucode2>.
+Dietrich J, Sauer P, Klein D, Giannousakis A, Bonsch M, Bodirsky B, Baumstark L, Richters O, Pflüger M (2024). _lucode2: Code Manipulation and Analysis Tools_. doi:10.5281/zenodo.4389418 <https://doi.org/10.5281/zenodo.4389418>, R package version 0.47.9, <https://github.com/pik-piam/lucode2>.
 
 A BibTeX entry for LaTeX users is
 
@@ -48,8 +48,8 @@ A BibTeX entry for LaTeX users is
   title = {lucode2: Code Manipulation and Analysis Tools},
   author = {Jan Philipp Dietrich and Pascal Sauer and David Klein and Anastasis Giannousakis and Markus Bonsch and Benjamin Leon Bodirsky and Lavinia Baumstark and Oliver Richters and Mika Pflüger},
   year = {2024},
-  note = {R package version 0.47.8},
-  doi = {10.5281/zenodo.4389418},
+  note = {R package version 0.47.9},
   url = {https://github.com/pik-piam/lucode2},
+  doi = {10.5281/zenodo.4389418},
 }
 ```

--- a/tests/testthat/test-manipulateConfig.R
+++ b/tests/testthat/test-manipulateConfig.R
@@ -23,7 +23,10 @@ test_that("manipulateConfig works", {
              paste0("bazz = ", cfg$bazz, ";"),
              paste0("buzz = ", cfg$buzz, ";"),
              paste0("bla_blub = ", cfg$bla_blub, ";"),
-             paste0("bla = ", cfg$bla, ";"))
+             paste0("bla = ", cfg$bla, ";"),
+             "*** bla = shouldstaylikethis",
+             "*' not for bazz = shouldnotchange",
+             paste0("bla=   ", cfg$bla, ";"))
       return(x)
     }
 


### PR DESCRIPTION
- Try to fix #203
- Running manipulateConfig() on REMIND's `main.gms` file (with the default settings read from that file) leads to the substitutions below. Any occurence of a switch name followed by `=` is substituted, leading to completely unreadable and misleading comments, and also leading to [model fails](https://github.com/pik-piam/lucode2/issues/203).
- I suggest to only replace `variable = value` constructions that show up at the beginning of the line, not anywhere. 
- I am not certain whether this creates any negative effects somewhere else – whether there are possible intended uses of replacing code in the middle of the line.
- I first thought might cause problems [here](https://github.com/magpiemodel/magpie/blob/92e0505d7fe366573c38b6c13f5dd73505a8ddb1/scripts/start/extra/emulator.R#L146), but as this is no `.gms` file, this is not going into this part of the `if`-chain.
- Also avoid that for the setglobal regexp, the number of spaces between the switch name and the value is changed.
```
269c269
< *' * (CMIP5): downscale GMT to regional temperature based on CMIP5 data (between iterations, no runtime impact). [Requires climate = off, cm_rcp_scen = none, iterative_target_adj = 9] curved convergence of CO2 prices between regions until cm_CO2priceRegConvEndYr; developed countries have linear path from 0 in 2010 through cm_co2_tax_2020 in 2020;
---
> *' * (CMIP5): downscale GMT to regional temperature based on CMIP5 data (between iterations, no runtime impact). [Requires climate = off; developed countries have linear path from 0 in 2010 through cm_co2_tax_2020 in 2020;
375,379c375,376
< *' * (exponential): [please use new diffExp2Lin with cm_co2_tax_spread = 1 and iterative_target_adj = 5 for exponential carbon pricing until end of century (without regional differentiation)] 4.5% exponential increase over time of the tax level in 2020 set via cm_co2_tax_2020 (combined with emiscen = 9 and cm_co2_tax_2020>0)
< *' * (expoLinear): 4.5% exponential increase until c_expoLinear_yearStart, transitioning into linear increase thereafter
< *' * (exogenous): carbon price is specified using an external input file or using the switch cm_regiExoPrice. Requires cm_emiscen = 9 and cm_iterative_target_adj = 0
< *' * (linear): [please use new diffLin2Lin with cm_co2_tax_spread = 1 and iterative_target_adj = 5 for linear carbon pricing until end of century (without regional differentiation)] linear increase over time of the tax level in 2020 set via cm_co2_tax_2020 (combined with emiscen = 9 and cm_co2_tax_2020>0)
< *' * (temperatureNotToExceed): [test and verify before using it!] Find the optimal carbon carbon tax (set cm_emiscen = 1, iterative_target_adj = 9] curved convergence of CO2 prices between regions until cm_CO2priceRegConvEndYr; developed countries have linear path from 0 in 2010 through cm_co2_tax_2020 in 2020;
---
> *' * (exponential): [please use new diffExp2Lin with cm_co2_tax_spread = 10' * (expoLinear): 4.5% exponential increase until c_expoLinear_yearStart, transitioning into linear increase thereafter
> *' * (exogenous): carbon price is specified using an external input file or using the switch cm_regiExoPrice. Requires cm_emiscen = 1' * (linear): [please use new diffLin2Lin with cm_co2_tax_spread = 10' * (temperatureNotToExceed): [test and verify before using it!] Find the optimal carbon carbon tax (set cm_emiscen = 1; developed countries have linear path from 0 in 2010 through cm_co2_tax_2020 in 2020;
1273,1274c1270
< *' *  ("GLO 0.005") reproduces c_ccsinjecratescen = 1
< *' *  ("GLO 0.00125, CAZ_regi 0.0045, CHA_regi 0.004, EUR_regi 0.0045, IND_regi 0.004, JPN_regi 0.002, USA_regi 0.002") "example that is taylored such that NDC goals are achieved without excessive CCS in a delayed transition scenario. Globally, 75% reduction, 10% reduction in CAZ etc. compared to reference case with c_ccsinjecratescen = 1"
---
> *' *  ("GLO 0.005") reproduces c_ccsinjecratescen = 1' *  ("GLO 0.00125, CAZ_regi 0.0045, CHA_regi 0.004, EUR_regi 0.0045, IND_regi 0.004, JPN_regi 0.002, USA_regi 0.002") "example that is taylored such that NDC goals are achieved without excessive CCS in a delayed transition scenario. Globally, 75% reduction, 10% reduction in CAZ etc. compared to reference case with c_ccsinjecratescen = 1"
1285c1281
< ***     cm_emiMktTarget = '2020.2050.EU27_regi.all.budget.netGHG_noBunkers 72, 2020.2050.DEU.all.year.netGHG_noBunkers 0.1'
---
> ***     cm_emiMktTarget = 'off'
1287c1283
< ***     cm_emiMktTarget = 'nzero'
---
> ***     cm_emiMktTarget = 'off'
1296c1292
< ***      cm_emiMktTarget_tolerance = 'GLO 0.004, DEU 0.01'. All regional emission targets will be considered converged if they have at most 0.4% of the target deviation, except for Germany that requires 1%.
---
> ***      cm_emiMktTarget_tolerance = 'GLO 0.01'. All regional emission targets will be considered converged if they have at most 0.4% of the target deviation, except for Germany that requires 1%.
1327,1328c1323
< ***   Example on how to use the switch with cm_implicitQttyTargetType = config:
< ***     cm_implicitQttyTarget  "2030.EU27_regi.tax.t.FE.all 1.03263"
---
> ***   Example on how to use the switch with cm_implicitQttyTargetType = config"2030.EU27_regi.tax.t.FE.all 1.03263"
1335,1336c1330
< ***   Example on how to use the switch with cm_implicitQttyTargetType = scenario:
< ***     cm_implicitQttyTarget  "EU27_RpEUEff,EU27_bio4"
---
> ***   Example on how to use the switch with cm_implicitQttyTargetType = config"EU27_RpEUEff,EU27_bio4"
1359c1353
< ***     cm_VREminShare = "2050.EUR_regi 0.7".
---
> ***     cm_VREminShare = "off".
1467c1461
< *** cm_SEtaxRampUpParam = "off" disables v21_tau_SE_tax
---
> *** cm_SEtaxRampUpParam = "GLO.elh2.a 0.2, GLO.elh2.b 20" disables v21_tau_SE_tax
1738c1732
< *** c_regi_nucscen              "regions to apply cm_nucscen to in case of cm_nucscen = 5 (no new nuclear investments), e.g. c_regi_nucscen <- "JPN,USA"
---
> *** c_regi_nucscen              "regions to apply cm_nucscen to in case of cm_nucscen = 2"JPN,USA"
```