### PR TITLE
Improve logo with multi-line title in README

### DIFF
--- a/.buildlibrary
+++ b/.buildlibrary
@@ -1,4 +1,4 @@
-ValidationKey: '94106936'
+ValidationKey: '94136336'
 AutocreateReadme: yes
 AcceptedWarnings:
 - 'Warning: package ''.*'' was built under R version'

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -2,8 +2,8 @@ cff-version: 1.2.0
 message: If you use this software, please cite it using the metadata from this file.
 type: software
 title: 'lucode2: Code Manipulation and Analysis Tools'
-version: 0.47.11
-date-released: '2024-09-10'
+version: 0.47.12
+date-released: '2024-09-12'
 abstract: A collection of tools which allow to manipulate and analyze code.
 authors:
 - family-names: Dietrich

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Type: Package
 Package: lucode2
 Title: Code Manipulation and Analysis Tools
-Version: 0.47.11
-Date: 2024-09-10
+Version: 0.47.12
+Date: 2024-09-12
 Authors@R: c(
     person("Jan Philipp", "Dietrich", email = "dietrich@pik-potsdam.de", 
     comment = c(affiliation = "Potsdam Institute for Climate Impact Research", ORCID = "0000-0002-4309-6431"), role = c("aut","cre")),

--- a/R/package2readme.R
+++ b/R/package2readme.R
@@ -220,10 +220,10 @@ package2readme <- function(package = ".", add = NULL, logo = NULL) { # nolint
 
   getTitle <- function(x, logo) {
     if (!is.null(logo)) {
-      x <- paste0(x,
-                  " <a href=''><img src='",
+      x <- paste0("<a href=''><img src='",
                   logo,
-                  "' align='right' height='139' /></a>")
+                  "' align='right' height=139 width=300 /></a>",
+                  x)
     }
     return(x)
   }

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Code Manipulation and Analysis Tools
 
-R package **lucode2**, version **0.47.11**
+R package **lucode2**, version **0.47.12**
 
 [![CRAN status](https://www.r-pkg.org/badges/version/lucode2)](https://cran.r-project.org/package=lucode2) [![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.4389418.svg)](https://doi.org/10.5281/zenodo.4389418) [![R build status](https://github.com/pik-piam/lucode2/workflows/check/badge.svg)](https://github.com/pik-piam/lucode2/actions) [![codecov](https://codecov.io/gh/pik-piam/lucode2/branch/master/graph/badge.svg)](https://app.codecov.io/gh/pik-piam/lucode2) [![r-universe](https://pik-piam.r-universe.dev/badges/lucode2)](https://pik-piam.r-universe.dev/builds)
 
@@ -39,7 +39,7 @@ In case of questions / problems please contact Jan Philipp Dietrich <dietrich@pi
 
 To cite package **lucode2** in publications use:
 
-Dietrich J, Sauer P, Klein D, Giannousakis A, Bonsch M, Bodirsky B, Baumstark L, Richters O, Pflüger M (2024). _lucode2: Code Manipulation and Analysis Tools_. doi:10.5281/zenodo.4389418 <https://doi.org/10.5281/zenodo.4389418>, R package version 0.47.11, <https://github.com/pik-piam/lucode2>.
+Dietrich J, Sauer P, Klein D, Giannousakis A, Bonsch M, Bodirsky B, Baumstark L, Richters O, Pflüger M (2024). _lucode2: Code Manipulation and Analysis Tools_. doi:10.5281/zenodo.4389418 <https://doi.org/10.5281/zenodo.4389418>, R package version 0.47.12, <https://github.com/pik-piam/lucode2>.
 
 A BibTeX entry for LaTeX users is
 
@@ -48,7 +48,7 @@ A BibTeX entry for LaTeX users is
   title = {lucode2: Code Manipulation and Analysis Tools},
   author = {Jan Philipp Dietrich and Pascal Sauer and David Klein and Anastasis Giannousakis and Markus Bonsch and Benjamin Leon Bodirsky and Lavinia Baumstark and Oliver Richters and Mika Pflüger},
   year = {2024},
-  note = {R package version 0.47.11},
+  note = {R package version 0.47.12},
   url = {https://github.com/pik-piam/lucode2},
   doi = {10.5281/zenodo.4389418},
 }


### PR DESCRIPTION
I did a minor modification to the way a logo is added to the `README.md`.
- The logo no comes before not after the title in the same line.
- I set not only the height but also the width

The `README` looks better now with logos with a wide aspect ratio (they got too large with a height of 139px) and multi-line package titles (they used to push the logo down too much).

There should be no changes in appearance if
- the logo has an aspect ratio below 300:139.
- the title fits on one line.

closes #208 