### PR TITLE
Avoid logo distortion

### DIFF
--- a/.buildlibrary
+++ b/.buildlibrary
@@ -1,4 +1,4 @@
-ValidationKey: '94136336'
+ValidationKey: '94161027'
 AutocreateReadme: yes
 AcceptedWarnings:
 - 'Warning: package ''.*'' was built under R version'

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -2,8 +2,8 @@ cff-version: 1.2.0
 message: If you use this software, please cite it using the metadata from this file.
 type: software
 title: 'lucode2: Code Manipulation and Analysis Tools'
-version: 0.47.12
-date-released: '2024-09-12'
+version: 0.47.13
+date-released: '2024-09-13'
 abstract: A collection of tools which allow to manipulate and analyze code.
 authors:
 - family-names: Dietrich

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Type: Package
 Package: lucode2
 Title: Code Manipulation and Analysis Tools
-Version: 0.47.12
-Date: 2024-09-12
+Version: 0.47.13
+Date: 2024-09-13
 Authors@R: c(
     person("Jan Philipp", "Dietrich", email = "dietrich@pik-potsdam.de", 
     comment = c(affiliation = "Potsdam Institute for Climate Impact Research", ORCID = "0000-0002-4309-6431"), role = c("aut","cre")),

--- a/R/buildLibrary.R
+++ b/R/buildLibrary.R
@@ -39,6 +39,7 @@
 #'                               in markdown format or as paths to RMarkdown (Rmd) or Markdown (md) files
 #' * **AddLogoReadme** (optional): Additional logo to be added to the autocreated README. Provided as
 #'                                 path to logo in PNG format
+#' * **LogoHeightReadme** (optional): Height of the logo in README in px
 #' * **AcceptedWarnings** (optional): a list of Warnings which should be ignored by `buildLibrary`
 #'                                    (autocompletion via asterisks allowed)
 #' * **AcceptedNotes** (optional): a list of Notes which should be ignored by `buildLibrary`
@@ -190,7 +191,8 @@ buildLibrary <- function(lib = ".", cran = TRUE, updateType = NULL,
   citation::r2cff(export = TRUE)
   if (isTRUE(cfg$AutocreateReadme)) {
     package2readme(add = cfg$AddInReadme,
-                   logo = cfg$AddLogoReadme)
+                   logo = cfg$AddLogoReadme,
+                   logoHeight = cfg$LogoHeightReadme)
   }
 
   ####################################################################

--- a/R/package2readme.R
+++ b/R/package2readme.R
@@ -7,6 +7,7 @@
 #' @param add a character vector with additions to the README file. Each element of the vector can be either
 #' 1) a line of markdown code, 2) a path to a markdown file, or 3) a path to a Rmarkdown file
 #' @param logo a character string for a path to a logo file used in the title of the README file
+#' @param logoHeight numeric, logo height in px
 #' @author Jan Philipp Dietrich
 #' @importFrom desc desc
 #' @importFrom utils citation vignette packageDescription
@@ -16,7 +17,7 @@
 #' @examples
 #' package2readme("lucode2")
 #' @export
-package2readme <- function(package = ".", add = NULL, logo = NULL) { # nolint
+package2readme <- function(package = ".", add = NULL, logo = NULL, logoHeight = NULL) { # nolint
   if (file.exists(file.path(package, "DESCRIPTION"))) {
     d <- desc(file = file.path(package, "DESCRIPTION"))
     folder <- package
@@ -218,17 +219,19 @@ package2readme <- function(package = ".", add = NULL, logo = NULL) { # nolint
     return(x)
   }
 
-  getTitle <- function(x, logo) {
+  getTitle <- function(x, logo, height) {
     if (!is.null(logo)) {
-      x <- paste0("<a href=''><img src='",
-                  logo,
-                  "' align='right' height=139 width=300 /></a>",
+      if (is.null(height)) {
+        height <- 139
+      }
+      x <- paste0("<a href=''><img src='", logo, "' align='right' alt='logo' ",
+                  "height=", height, " /></a> ",
                   x)
     }
     return(x)
   }
 
-  fill <- list(title         = getTitle(d$get("Title"), logo),
+  fill <- list(title         = getTitle(d$get("Title"), logo, logoHeight),
                package       = d$get("Package"),
                description   = d$get("Description"),
                additions     = fillAdditions(add, folder),

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Code Manipulation and Analysis Tools
 
-R package **lucode2**, version **0.47.12**
+R package **lucode2**, version **0.47.13**
 
 [![CRAN status](https://www.r-pkg.org/badges/version/lucode2)](https://cran.r-project.org/package=lucode2) [![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.4389418.svg)](https://doi.org/10.5281/zenodo.4389418) [![R build status](https://github.com/pik-piam/lucode2/workflows/check/badge.svg)](https://github.com/pik-piam/lucode2/actions) [![codecov](https://codecov.io/gh/pik-piam/lucode2/branch/master/graph/badge.svg)](https://app.codecov.io/gh/pik-piam/lucode2) [![r-universe](https://pik-piam.r-universe.dev/badges/lucode2)](https://pik-piam.r-universe.dev/builds)
 
@@ -39,7 +39,7 @@ In case of questions / problems please contact Jan Philipp Dietrich <dietrich@pi
 
 To cite package **lucode2** in publications use:
 
-Dietrich J, Sauer P, Klein D, Giannousakis A, Bonsch M, Bodirsky B, Baumstark L, Richters O, Pflüger M (2024). _lucode2: Code Manipulation and Analysis Tools_. doi:10.5281/zenodo.4389418 <https://doi.org/10.5281/zenodo.4389418>, R package version 0.47.12, <https://github.com/pik-piam/lucode2>.
+Dietrich J, Sauer P, Klein D, Giannousakis A, Bonsch M, Bodirsky B, Baumstark L, Richters O, Pflüger M (2024). _lucode2: Code Manipulation and Analysis Tools_. doi:10.5281/zenodo.4389418 <https://doi.org/10.5281/zenodo.4389418>, R package version 0.47.13, <https://github.com/pik-piam/lucode2>.
 
 A BibTeX entry for LaTeX users is
 
@@ -48,7 +48,7 @@ A BibTeX entry for LaTeX users is
   title = {lucode2: Code Manipulation and Analysis Tools},
   author = {Jan Philipp Dietrich and Pascal Sauer and David Klein and Anastasis Giannousakis and Markus Bonsch and Benjamin Leon Bodirsky and Lavinia Baumstark and Oliver Richters and Mika Pflüger},
   year = {2024},
-  note = {R package version 0.47.12},
+  note = {R package version 0.47.13},
   url = {https://github.com/pik-piam/lucode2},
   doi = {10.5281/zenodo.4389418},
 }

--- a/man/buildLibrary.Rd
+++ b/man/buildLibrary.Rd
@@ -56,6 +56,7 @@ the README.md file or not (default: yes)
 in markdown format or as paths to RMarkdown (Rmd) or Markdown (md) files
 \item \strong{AddLogoReadme} (optional): Additional logo to be added to the autocreated README. Provided as
 path to logo in PNG format
+\item \strong{LogoHeightReadme} (optional): Height of the logo in README in px
 \item \strong{AcceptedWarnings} (optional): a list of Warnings which should be ignored by \code{buildLibrary}
 (autocompletion via asterisks allowed)
 \item \strong{AcceptedNotes} (optional): a list of Notes which should be ignored by \code{buildLibrary}

--- a/man/package2readme.Rd
+++ b/man/package2readme.Rd
@@ -4,7 +4,7 @@
 \alias{package2readme}
 \title{package2readme}
 \usage{
-package2readme(package = ".", add = NULL, logo = NULL)
+package2readme(package = ".", add = NULL, logo = NULL, logoHeight = NULL)
 }
 \arguments{
 \item{package}{either the path to the main folder of a package (containing a DESCRIPTION file)
@@ -14,6 +14,8 @@ or the name of the package}
 1) a line of markdown code, 2) a path to a markdown file, or 3) a path to a Rmarkdown file}
 
 \item{logo}{a character string for a path to a logo file used in the title of the README file}
+
+\item{logoHeight}{numeric, logo height in px}
 }
 \description{
 Creates a README.md for a R package.


### PR DESCRIPTION
~~Sets maximum height and width for the logo in README instead of fixed values to avoid distortion.~~

Instead of maximum height and width (not supported by github markdowns), logos are inserted only giving the height (just like before the problematic #209). But this height can now be changed from its default value of 139 px if one sets `LogoHeightReadme` in `.buildlibrary`.