### PR TITLE
add 'skipCoverage' option to build library config

### DIFF
--- a/.buildlibrary
+++ b/.buildlibrary
@@ -1,4 +1,4 @@
-ValidationKey: '94312998'
+ValidationKey: '9609120'
 AutocreateReadme: yes
 AcceptedWarnings:
 - 'Warning: package ''.*'' was built under R version'
@@ -8,3 +8,4 @@ AcceptedNotes:
 - 'Package suggested but not available for checking: .poorman.'
 allowLinterWarnings: no
 enforceVersionUpdate: no
+skipCoverage: no

--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -63,6 +63,6 @@ jobs:
         shell: Rscript {0}
         run: |
           nonDummyTests <- setdiff(list.files("./tests/testthat/"), c("test-dummy.R", "_snaps"))
-          if(length(nonDummyTests) > 0) covr::codecov(quiet = FALSE)
+          if(length(nonDummyTests) > 0 && !lucode2:::loadBuildLibraryConfig()[["skipCoverage"]]) covr::codecov(quiet = FALSE)
         env:
           NOT_CRAN: "true"

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -2,8 +2,8 @@ cff-version: 1.2.0
 message: If you use this software, please cite it using the metadata from this file.
 type: software
 title: 'lucode2: Code Manipulation and Analysis Tools'
-version: 0.47.14
-date-released: '2024-10-11'
+version: 0.48.0
+date-released: '2024-10-23'
 abstract: A collection of tools which allow to manipulate and analyze code.
 authors:
 - family-names: Dietrich

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Type: Package
 Package: lucode2
 Title: Code Manipulation and Analysis Tools
-Version: 0.47.14
-Date: 2024-10-11
+Version: 0.48.0
+Date: 2024-10-23
 Authors@R: c(
     person("Jan Philipp", "Dietrich", email = "dietrich@pik-potsdam.de", 
     comment = c(affiliation = "Potsdam Institute for Climate Impact Research", ORCID = "0000-0002-4309-6431"), role = c("aut","cre")),

--- a/R/buildLibrary.R
+++ b/R/buildLibrary.R
@@ -46,6 +46,11 @@
 #'                                    (autocompletion via asterisks allowed)
 #' * **allowLinterWarnings**: yes/no - If set to "no" linter warnings will stop the build process.
 #'                            (default: yes)
+#' * **enforceVersionUpdate**: yes/no - If set to "yes", the version number must
+#'                                    be incremented to a non-dev version number
+#'                                    for the build process to succeed. (default: no)
+#' * **skipCoverage**: yes/no - If set to "yes", running code coverage using covr
+#'                              as part of the GitHub workflow will be skipped. (default: no)
 #' @author Jan Philipp Dietrich, Anastasis Giannousakis, Markus Bonsch, Pascal Sauer
 #' @seealso \code{\link{package2readme}}, \code{\link{lint}}, \code{\link{autoFormat}}
 #' @importFrom desc desc desc_get_deps

--- a/R/isVersionUpdated.R
+++ b/R/isVersionUpdated.R
@@ -1,7 +1,7 @@
 #' isVersionUpdated
 #'
 #' Checks if the version number in the DESCRIPTION file of a given package has
-#' been updated.
+#' been updated (may not be a version number for development stage packages).
 #' @param repo package repository to determine latest version
 #' @param config A configuration defining enforceVersionUpdate. By default
 #' the .buildLibrary file is read.

--- a/R/loadBuildLibraryConfig.R
+++ b/R/loadBuildLibraryConfig.R
@@ -61,5 +61,9 @@ loadBuildLibraryConfig <- function(lib = ".") {
     cfg$enforceVersionUpdate <- FALSE
   }
 
+  if (is.null(cfg$skipCoverage)) {
+    cfg$skipCoverage <- FALSE
+  }
+
   return(cfg)
 }

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Code Manipulation and Analysis Tools
 
-R package **lucode2**, version **0.47.14**
+R package **lucode2**, version **0.48.0**
 
 [![CRAN status](https://www.r-pkg.org/badges/version/lucode2)](https://cran.r-project.org/package=lucode2) [![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.4389418.svg)](https://doi.org/10.5281/zenodo.4389418) [![R build status](https://github.com/pik-piam/lucode2/workflows/check/badge.svg)](https://github.com/pik-piam/lucode2/actions) [![codecov](https://codecov.io/gh/pik-piam/lucode2/branch/master/graph/badge.svg)](https://app.codecov.io/gh/pik-piam/lucode2) [![r-universe](https://pik-piam.r-universe.dev/badges/lucode2)](https://pik-piam.r-universe.dev/builds)
 
@@ -39,7 +39,7 @@ In case of questions / problems please contact Jan Philipp Dietrich <dietrich@pi
 
 To cite package **lucode2** in publications use:
 
-Dietrich J, Sauer P, Klein D, Giannousakis A, Bonsch M, Bodirsky B, Baumstark L, Richters O, Pflüger M (2024). _lucode2: Code Manipulation and Analysis Tools_. doi:10.5281/zenodo.4389418 <https://doi.org/10.5281/zenodo.4389418>, R package version 0.47.14, <https://github.com/pik-piam/lucode2>.
+Dietrich J, Sauer P, Klein D, Giannousakis A, Bonsch M, Bodirsky B, Baumstark L, Richters O, Pflüger M (2024). _lucode2: Code Manipulation and Analysis Tools_. doi:10.5281/zenodo.4389418 <https://doi.org/10.5281/zenodo.4389418>, R package version 0.48.0, <https://github.com/pik-piam/lucode2>.
 
 A BibTeX entry for LaTeX users is
 
@@ -48,7 +48,7 @@ A BibTeX entry for LaTeX users is
   title = {lucode2: Code Manipulation and Analysis Tools},
   author = {Jan Philipp Dietrich and Pascal Sauer and David Klein and Anastasis Giannousakis and Markus Bonsch and Benjamin Leon Bodirsky and Lavinia Baumstark and Oliver Richters and Mika Pflüger},
   year = {2024},
-  note = {R package version 0.47.14},
+  note = {R package version 0.48.0},
   url = {https://github.com/pik-piam/lucode2},
   doi = {10.5281/zenodo.4389418},
 }

--- a/inst/extdata/check.yaml
+++ b/inst/extdata/check.yaml
@@ -63,6 +63,6 @@ jobs:
         shell: Rscript {0}
         run: |
           nonDummyTests <- setdiff(list.files("./tests/testthat/"), c("test-dummy.R", "_snaps"))
-          if(length(nonDummyTests) > 0) covr::codecov(quiet = FALSE)
+          if(length(nonDummyTests) > 0 && !lucode2:::loadBuildLibraryConfig()[["skipCoverage"]]) covr::codecov(quiet = FALSE)
         env:
           NOT_CRAN: "true"

--- a/man/buildLibrary.Rd
+++ b/man/buildLibrary.Rd
@@ -63,6 +63,11 @@ path to logo in PNG format
 (autocompletion via asterisks allowed)
 \item \strong{allowLinterWarnings}: yes/no - If set to "no" linter warnings will stop the build process.
 (default: yes)
+\item \strong{enforceVersionUpdate}: yes/no - If set to "yes", the version number must
+be incremented to a non-dev version number
+for the build process to succeed. (default: no)
+\item \strong{skipCoverage}: yes/no - If set to "yes", running code coverage using covr
+as part of the GitHub workflow will be skipped. (default: no)
 }
 }
 \examples{

--- a/man/isVersionUpdated.Rd
+++ b/man/isVersionUpdated.Rd
@@ -17,7 +17,7 @@ the .buildLibrary file is read.}
 }
 \description{
 Checks if the version number in the DESCRIPTION file of a given package has
-been updated.
+been updated (may not be a version number for development stage packages).
 }
 \author{
 Falk Benke


### PR DESCRIPTION
This allows for packages to skip test coverage as part of the Github workflow checks by setting `skipCoverage: yes` in `.buildlibrary`