### PR TITLE
include JOSS badge

### DIFF
--- a/.buildlibrary
+++ b/.buildlibrary
@@ -1,4 +1,4 @@
-ValidationKey: '9609120'
+ValidationKey: '9645974'
 AutocreateReadme: yes
 AcceptedWarnings:
 - 'Warning: package ''.*'' was built under R version'

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -2,8 +2,8 @@ cff-version: 1.2.0
 message: If you use this software, please cite it using the metadata from this file.
 type: software
 title: 'lucode2: Code Manipulation and Analysis Tools'
-version: 0.48.0
-date-released: '2024-10-23'
+version: 0.48.1
+date-released: '2024-11-27'
 abstract: A collection of tools which allow to manipulate and analyze code.
 authors:
 - family-names: Dietrich

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Type: Package
 Package: lucode2
 Title: Code Manipulation and Analysis Tools
-Version: 0.48.0
-Date: 2024-10-23
+Version: 0.48.1
+Date: 2024-11-27
 Authors@R: c(
     person("Jan Philipp", "Dietrich", email = "dietrich@pik-potsdam.de", 
     comment = c(affiliation = "Potsdam Institute for Climate Impact Research", ORCID = "0000-0002-4309-6431"), role = c("aut","cre")),

--- a/R/citationDoi.R
+++ b/R/citationDoi.R
@@ -9,7 +9,7 @@ citationDoi <- function(meta) {
     urls <- grep("http", tmp, value = TRUE)
     cit$note <- paste0(grep("http", tmp, value = TRUE, invert = TRUE), collapse = ", ")
     cit$doi <- gsub("\n", "", gsub("https://doi.org/", "",
-                                   grep("doi.org", urls, fixed = TRUE, value = TRUE), fixed = TRUE))
+                                   grep("doi\\.org.*zenodo", urls, value = TRUE), fixed = TRUE))
     cit$url <- c(cit$url, grep("doi.org", urls, fixed = TRUE, value = TRUE, invert = TRUE))
     if (cit$note == "") cit$note <- paste("R package version", meta$Version)
     if (!length(cit$url)) cit$url <- NULL

--- a/R/citationDoi.R
+++ b/R/citationDoi.R
@@ -9,7 +9,7 @@ citationDoi <- function(meta) {
     urls <- grep("http", tmp, value = TRUE)
     cit$note <- paste0(grep("http", tmp, value = TRUE, invert = TRUE), collapse = ", ")
     cit$doi <- gsub("\n", "", gsub("https://doi.org/", "",
-                                   grep("doi\\.org.*zenodo", urls, value = TRUE), fixed = TRUE))
+                                   grep("doi.org", urls[1], fixed = TRUE, value = TRUE), fixed = TRUE))
     cit$url <- c(cit$url, grep("doi.org", urls, fixed = TRUE, value = TRUE, invert = TRUE))
     if (cit$note == "") cit$note <- paste("R package version", meta$Version)
     if (!length(cit$url)) cit$url <- NULL

--- a/R/package2readme.R
+++ b/R/package2readme.R
@@ -83,6 +83,15 @@ package2readme <- function(package = ".", add = NULL, logo = NULL, logoHeight = 
     return(out)
   }
 
+  fillJOSS <- function(d) {
+    z <- grep("joss", d$get_urls(), value = TRUE)
+    if (length(z) == 0) return("")
+    doi <- strsplit(z, "doi.org/", fixed = TRUE)[[1]][2]
+    out <- paste0("[![DOI](https://joss.theoj.org/papers/", doi,
+                  "/status.svg)](https://doi.org/", doi, ")")
+    return(out)
+  }
+
   fillZenodo <- function(d) {
     z <- grep("zenodo", d$get_urls(), value = TRUE)
     if (length(z) == 0) return("")
@@ -238,6 +247,7 @@ package2readme <- function(package = ".", add = NULL, logo = NULL, logoHeight = 
                version       = d$get("Version"),
                maintainer    = d$get_maintainer(),
                cran          = fillCRAN(d),
+               joss          = fillJOSS(d),
                zenodo        = fillZenodo(d),
                githubactions = fillGithubActions(d, folder),
                codecov       = fillCodecov(d, folder),

--- a/R/package2readme.R
+++ b/R/package2readme.R
@@ -88,7 +88,7 @@ package2readme <- function(package = ".", add = NULL, logo = NULL, logoHeight = 
     if (length(z) == 0) return("")
     doi <- strsplit(z, "doi.org/", fixed = TRUE)[[1]][2]
     out <- paste0("[![DOI](https://joss.theoj.org/papers/", doi,
-                  "/status.svg)](https://doi.org/", doi, ") ")
+                  "/status.svg)](https://doi.org/", doi, ")")
     return(out)
   }
 
@@ -225,6 +225,9 @@ package2readme <- function(package = ".", add = NULL, logo = NULL, logoHeight = 
       if (is.null(fill[[what]])) fill[[what]] <- ""
       x <- gsub(paste0("[:", what, ":]"), fill[[what]], x, fixed = TRUE)
     }
+    # Replace multiple spaces between `)`and `[` due to empty placeholders
+    # with a single space
+    x <- gsub("\\)\\s+\\[", ") [", x)
     return(x)
   }
 

--- a/R/package2readme.R
+++ b/R/package2readme.R
@@ -88,7 +88,7 @@ package2readme <- function(package = ".", add = NULL, logo = NULL, logoHeight = 
     if (length(z) == 0) return("")
     doi <- strsplit(z, "doi.org/", fixed = TRUE)[[1]][2]
     out <- paste0("[![DOI](https://joss.theoj.org/papers/", doi,
-                  "/status.svg)](https://doi.org/", doi, ")")
+                  "/status.svg)](https://doi.org/", doi, ") ")
     return(out)
   }
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 R package **lucode2**, version **0.48.3**
 
-[![CRAN status](https://www.r-pkg.org/badges/version/lucode2)](https://cran.r-project.org/package=lucode2) [:joss:][![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.4389418.svg)](https://doi.org/10.5281/zenodo.4389418) [![R build status](https://github.com/pik-piam/lucode2/workflows/check/badge.svg)](https://github.com/pik-piam/lucode2/actions) [![codecov](https://codecov.io/gh/pik-piam/lucode2/branch/master/graph/badge.svg)](https://app.codecov.io/gh/pik-piam/lucode2) [![r-universe](https://pik-piam.r-universe.dev/badges/lucode2)](https://pik-piam.r-universe.dev/builds)
+[![CRAN status](https://www.r-pkg.org/badges/version/lucode2)](https://cran.r-project.org/package=lucode2) [![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.4389418.svg)](https://doi.org/10.5281/zenodo.4389418) [![R build status](https://github.com/pik-piam/lucode2/workflows/check/badge.svg)](https://github.com/pik-piam/lucode2/actions) [![codecov](https://codecov.io/gh/pik-piam/lucode2/branch/master/graph/badge.svg)](https://app.codecov.io/gh/pik-piam/lucode2) [![r-universe](https://pik-piam.r-universe.dev/badges/lucode2)](https://pik-piam.r-universe.dev/builds)
 
 ## Purpose and Functionality
 

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # Code Manipulation and Analysis Tools
 
-R package **lucode2**, version **0.48.0**
+R package **lucode2**, version **0.48.1**
 
-[![CRAN status](https://www.r-pkg.org/badges/version/lucode2)](https://cran.r-project.org/package=lucode2) [![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.4389418.svg)](https://doi.org/10.5281/zenodo.4389418) [![R build status](https://github.com/pik-piam/lucode2/workflows/check/badge.svg)](https://github.com/pik-piam/lucode2/actions) [![codecov](https://codecov.io/gh/pik-piam/lucode2/branch/master/graph/badge.svg)](https://app.codecov.io/gh/pik-piam/lucode2) [![r-universe](https://pik-piam.r-universe.dev/badges/lucode2)](https://pik-piam.r-universe.dev/builds)
+[![CRAN status](https://www.r-pkg.org/badges/version/lucode2)](https://cran.r-project.org/package=lucode2)  [![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.4389418.svg)](https://doi.org/10.5281/zenodo.4389418) [![R build status](https://github.com/pik-piam/lucode2/workflows/check/badge.svg)](https://github.com/pik-piam/lucode2/actions) [![codecov](https://codecov.io/gh/pik-piam/lucode2/branch/master/graph/badge.svg)](https://app.codecov.io/gh/pik-piam/lucode2) [![r-universe](https://pik-piam.r-universe.dev/badges/lucode2)](https://pik-piam.r-universe.dev/builds)
 
 ## Purpose and Functionality
 
@@ -39,7 +39,7 @@ In case of questions / problems please contact Jan Philipp Dietrich <dietrich@pi
 
 To cite package **lucode2** in publications use:
 
-Dietrich J, Sauer P, Klein D, Giannousakis A, Bonsch M, Bodirsky B, Baumstark L, Richters O, Pflüger M (2024). _lucode2: Code Manipulation and Analysis Tools_. doi:10.5281/zenodo.4389418 <https://doi.org/10.5281/zenodo.4389418>, R package version 0.48.0, <https://github.com/pik-piam/lucode2>.
+Dietrich J, Sauer P, Klein D, Giannousakis A, Bonsch M, Bodirsky B, Baumstark L, Richters O, Pflüger M (2024). _lucode2: Code Manipulation and Analysis Tools_. doi:10.5281/zenodo.4389418 <https://doi.org/10.5281/zenodo.4389418>, R package version 0.48.1, <https://github.com/pik-piam/lucode2>.
 
 A BibTeX entry for LaTeX users is
 
@@ -48,7 +48,7 @@ A BibTeX entry for LaTeX users is
   title = {lucode2: Code Manipulation and Analysis Tools},
   author = {Jan Philipp Dietrich and Pascal Sauer and David Klein and Anastasis Giannousakis and Markus Bonsch and Benjamin Leon Bodirsky and Lavinia Baumstark and Oliver Richters and Mika Pflüger},
   year = {2024},
-  note = {R package version 0.48.0},
+  note = {R package version 0.48.1},
   url = {https://github.com/pik-piam/lucode2},
   doi = {10.5281/zenodo.4389418},
 }

--- a/inst/extdata/README_template.md
+++ b/inst/extdata/README_template.md
@@ -2,7 +2,7 @@
 
 R package **[:package:]**, version **[:version:]**
 
-[:cran:] [:joss:][:zenodo:] [:githubactions:] [:codecov:] [:runiverse:]
+[:cran:] [:joss:] [:zenodo:] [:githubactions:] [:codecov:] [:runiverse:]
 
 ## Purpose and Functionality
 

--- a/inst/extdata/README_template.md
+++ b/inst/extdata/README_template.md
@@ -2,7 +2,7 @@
 
 R package **[:package:]**, version **[:version:]**
 
-[:cran:] [:joss:] [:zenodo:] [:githubactions:] [:codecov:] [:runiverse:]
+[:cran:] [:joss:][:zenodo:] [:githubactions:] [:codecov:] [:runiverse:]
 
 ## Purpose and Functionality
 

--- a/inst/extdata/README_template.md
+++ b/inst/extdata/README_template.md
@@ -2,7 +2,7 @@
 
 R package **[:package:]**, version **[:version:]**
 
-[:cran:] [:zenodo:] [:githubactions:] [:codecov:] [:runiverse:]
+[:cran:] [:joss:] [:zenodo:] [:githubactions:] [:codecov:] [:runiverse:]
 
 ## Purpose and Functionality
 


### PR DESCRIPTION
Dear @tscheypidi,
lpjmlkit has just been published on [JOSS](https://doi.org/10.21105/joss.05447), so we would like to acknowledge this. 
Our minimum requirement would be to add the JOSS badge next to the other badges in the README.  
[Here is how it looks like](https://github.com/jnnsbrr/lpjmlkit/tree/joss_in_readme).  

That's what I created this PR for.  
It adds the badge but lucode2 seems to have issues in handling additional DOIs being added to the DESCRIPTION.  

Issues are:
* the order of joss doi and zenodo doi determine which doi is included in the `"CITATION.cff"` file (only one is included)
* without the fix in `"citationDOI.R"` the DOIs get mixed up in the CITATION section in the `"README.md"`

Now the question is would it make sense to add a citation for JOSS (e.g. bibtex file) or replace the zotero citation in the citation section? What would you recommend? How to deal with these "additional" publications?  
I set this PR to draft status so we can discuss a preferred solution.  

Thanks a lot in advance!