### PR TITLE
Improve clearity: Remove unnecessary inversion of logical

### DIFF
--- a/.buildlibrary
+++ b/.buildlibrary
@@ -1,4 +1,4 @@
-ValidationKey: '9609120'
+ValidationKey: '9646455'
 AutocreateReadme: yes
 AcceptedWarnings:
 - 'Warning: package ''.*'' was built under R version'

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -2,8 +2,8 @@ cff-version: 1.2.0
 message: If you use this software, please cite it using the metadata from this file.
 type: software
 title: 'lucode2: Code Manipulation and Analysis Tools'
-version: 0.48.0
-date-released: '2024-10-23'
+version: 0.48.1
+date-released: '2024-11-28'
 abstract: A collection of tools which allow to manipulate and analyze code.
 authors:
 - family-names: Dietrich

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Type: Package
 Package: lucode2
 Title: Code Manipulation and Analysis Tools
-Version: 0.48.0
-Date: 2024-10-23
+Version: 0.48.1
+Date: 2024-11-28
 Authors@R: c(
     person("Jan Philipp", "Dietrich", email = "dietrich@pik-potsdam.de", 
     comment = c(affiliation = "Potsdam Institute for Climate Impact Research", ORCID = "0000-0002-4309-6431"), role = c("aut","cre")),

--- a/R/check.R
+++ b/R/check.R
@@ -140,7 +140,7 @@ verifyTests <- function(acceptedWarnings) {
 #'
 #' @author Pascal Sauer
 #' @export
-verifyLinter <- function(allowLinterWarnings = TRUE) {
+verifyLinter <- function(allowLinterWarnings = FALSE) {
   linterResults <- lucode2::lint()
   message("linter results:")
   print(linterResults)

--- a/R/check.R
+++ b/R/check.R
@@ -47,7 +47,7 @@ check <- function(lib = ".", cran = TRUE, config = loadBuildLibraryConfig(lib), 
     logs[["linter"]] <- withr::local_tempfile(pattern = "linter", fileext = ".log")
     message("running linter in background, see ", logs[["linter"]])
     processes[["linter"]] <- callr::r_bg(function(...) lucode2::verifyLinter(...),
-                                         args = list(isFALSE(config[["allowLinterWarnings"]])),
+                                         args = list(config[["allowLinterWarnings"]]),
                                          stdout = logs[["linter"]], stderr = "2>&1")
   }
 
@@ -136,11 +136,11 @@ verifyTests <- function(acceptedWarnings) {
 #'
 #' Run linter and stop on linter warning unless linter warnings are allowed.
 #'
-#' @param allowLinterWarnings If FALSE (the default) will stop on linter warnings.
+#' @param allowLinterWarnings If FALSE will stop on linter warnings.
 #'
 #' @author Pascal Sauer
 #' @export
-verifyLinter <- function(allowLinterWarnings = FALSE) {
+verifyLinter <- function(allowLinterWarnings = TRUE) {
   linterResults <- lucode2::lint()
   message("linter results:")
   print(linterResults)
@@ -148,7 +148,7 @@ verifyLinter <- function(allowLinterWarnings = FALSE) {
     autoFormatExcludeInfo <- paste("Running lucode2::autoFormat() might fix some warnings. If really needed (e.g.",
                                    "to prevent breaking an interface), see ?lintr::exclude on how to disable the",
                                    "linter for some lines.")
-    if (allowLinterWarnings) {
+    if (isFALSE(allowLinterWarnings)) {
       stop("There were linter warnings. They have to be fixed to successfully complete lucode2::buildLibrary. ",
            autoFormatExcludeInfo,
            " You can find solutions to common problems at https://github.com/pik-piam/discussions/discussions/18")

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Code Manipulation and Analysis Tools
 
-R package **lucode2**, version **0.48.0**
+R package **lucode2**, version **0.48.1**
 
 [![CRAN status](https://www.r-pkg.org/badges/version/lucode2)](https://cran.r-project.org/package=lucode2) [![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.4389418.svg)](https://doi.org/10.5281/zenodo.4389418) [![R build status](https://github.com/pik-piam/lucode2/workflows/check/badge.svg)](https://github.com/pik-piam/lucode2/actions) [![codecov](https://codecov.io/gh/pik-piam/lucode2/branch/master/graph/badge.svg)](https://app.codecov.io/gh/pik-piam/lucode2) [![r-universe](https://pik-piam.r-universe.dev/badges/lucode2)](https://pik-piam.r-universe.dev/builds)
 
@@ -39,7 +39,7 @@ In case of questions / problems please contact Jan Philipp Dietrich <dietrich@pi
 
 To cite package **lucode2** in publications use:
 
-Dietrich J, Sauer P, Klein D, Giannousakis A, Bonsch M, Bodirsky B, Baumstark L, Richters O, Pflüger M (2024). _lucode2: Code Manipulation and Analysis Tools_. doi:10.5281/zenodo.4389418 <https://doi.org/10.5281/zenodo.4389418>, R package version 0.48.0, <https://github.com/pik-piam/lucode2>.
+Dietrich J, Sauer P, Klein D, Giannousakis A, Bonsch M, Bodirsky B, Baumstark L, Richters O, Pflüger M (2024). _lucode2: Code Manipulation and Analysis Tools_. doi:10.5281/zenodo.4389418 <https://doi.org/10.5281/zenodo.4389418>, R package version 0.48.1, <https://github.com/pik-piam/lucode2>.
 
 A BibTeX entry for LaTeX users is
 
@@ -48,7 +48,7 @@ A BibTeX entry for LaTeX users is
   title = {lucode2: Code Manipulation and Analysis Tools},
   author = {Jan Philipp Dietrich and Pascal Sauer and David Klein and Anastasis Giannousakis and Markus Bonsch and Benjamin Leon Bodirsky and Lavinia Baumstark and Oliver Richters and Mika Pflüger},
   year = {2024},
-  note = {R package version 0.48.0},
+  note = {R package version 0.48.1},
   url = {https://github.com/pik-piam/lucode2},
   doi = {10.5281/zenodo.4389418},
 }

--- a/man/verifyLinter.Rd
+++ b/man/verifyLinter.Rd
@@ -4,10 +4,10 @@
 \alias{verifyLinter}
 \title{verifyLinter}
 \usage{
-verifyLinter(allowLinterWarnings = FALSE)
+verifyLinter(allowLinterWarnings = TRUE)
 }
 \arguments{
-\item{allowLinterWarnings}{If FALSE (the default) will stop on linter warnings.}
+\item{allowLinterWarnings}{If FALSE will stop on linter warnings.}
 }
 \description{
 Run linter and stop on linter warning unless linter warnings are allowed.


### PR DESCRIPTION
I was irritated by the inverted interpretation of `allowLinterWarnings` inside `verifyLinter` so I changed it. This should improve readability and have no effect of the correct functioning of the function.