### PR TITLE
run pre-commit via github action

### DIFF
--- a/.buildlibrary
+++ b/.buildlibrary
@@ -1,4 +1,4 @@
-ValidationKey: '9909793'
+ValidationKey: '10051000'
 AutocreateReadme: yes
 AutocreateCITATION: yes
 AcceptedWarnings:

--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -44,6 +44,8 @@ jobs:
           [ -f requirements.txt ] && python -m pip install --upgrade pip wheel || true
           [ -f requirements.txt ] && pip install -r requirements.txt || true
 
+      - uses: pre-commit/action@v3.0.1
+
       - name: Verify validation key
         shell: Rscript {0}
         run: lucode2:::validkey(stopIfInvalid = TRUE)
@@ -66,13 +68,3 @@ jobs:
           if(length(nonDummyTests) > 0 && !lucode2:::loadBuildLibraryConfig()[["skipCoverage"]]) covr::codecov(quiet = FALSE)
         env:
           NOT_CRAN: "true"
-
-  pre-commit:
-    runs-on: ubuntu-latest
-    steps:
-    - uses: actions/checkout@v4
-    - uses: actions/setup-python@v5
-      with:
-        python-version: 3
-    - uses: r-lib/actions/setup-r@v2
-    - uses: pre-commit/action@v3.0.1

--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -45,6 +45,7 @@ jobs:
           [ -f requirements.txt ] && pip install -r requirements.txt || true
 
       - name: Run pre-commit checks
+        shell: bash
         run: |
           python -m pip install pre-commit
           python -m pip freeze --local

--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -39,6 +39,8 @@ jobs:
         with:
           python-version: 3.9
 
+      - uses: pre-commit/action@v3.0.1
+
       - name: Install python dependencies if applicable
         run: |
           [ -f requirements.txt ] && python -m pip install --upgrade pip wheel || true

--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -44,7 +44,11 @@ jobs:
           [ -f requirements.txt ] && python -m pip install --upgrade pip wheel || true
           [ -f requirements.txt ] && pip install -r requirements.txt || true
 
-      - uses: pre-commit/action@v3.0.1
+      - name: Run pre-commit checks
+        run: |
+          python -m pip install pre-commit
+          python -m pip freeze --local
+          pre-commit run --show-diff-on-failure --color=always --all-files
 
       - name: Verify validation key
         shell: Rscript {0}

--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -70,10 +70,7 @@ jobs:
   pre-commit:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
-    - uses: actions/setup-python@v3
+    - uses: actions/checkout@v4
+    - uses: actions/setup-python@v5
     - uses: r-lib/actions/setup-r@v2
-      with:
-        use-public-rspm: true
-        extra-repositories: "https://rse.pik-potsdam.de/r/packages"
     - uses: pre-commit/action@v3.0.1

--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -39,8 +39,6 @@ jobs:
         with:
           python-version: 3.9
 
-      - uses: pre-commit/action@v3.0.1
-
       - name: Install python dependencies if applicable
         run: |
           [ -f requirements.txt ] && python -m pip install --upgrade pip wheel || true
@@ -68,3 +66,10 @@ jobs:
           if(length(nonDummyTests) > 0 && !lucode2:::loadBuildLibraryConfig()[["skipCoverage"]]) covr::codecov(quiet = FALSE)
         env:
           NOT_CRAN: "true"
+
+  pre-commit:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+    - uses: actions/setup-python@v3
+    - uses: pre-commit/action@v3.0.1

--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -73,7 +73,7 @@ jobs:
     - uses: actions/checkout@v3
     - uses: actions/setup-python@v3
     - uses: r-lib/actions/setup-r@v2
-        with:
-          use-public-rspm: true
-          extra-repositories: "https://rse.pik-potsdam.de/r/packages"
+      with:
+        use-public-rspm: true
+        extra-repositories: "https://rse.pik-potsdam.de/r/packages"
     - uses: pre-commit/action@v3.0.1

--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -72,4 +72,8 @@ jobs:
     steps:
     - uses: actions/checkout@v3
     - uses: actions/setup-python@v3
+    - uses: r-lib/actions/setup-r@v2
+        with:
+          use-public-rspm: true
+          extra-repositories: "https://rse.pik-potsdam.de/r/packages"
     - uses: pre-commit/action@v3.0.1

--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -72,5 +72,7 @@ jobs:
     steps:
     - uses: actions/checkout@v4
     - uses: actions/setup-python@v5
+      with:
+        python-version: 3
     - uses: r-lib/actions/setup-r@v2
     - uses: pre-commit/action@v3.0.1

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -2,8 +2,8 @@ cff-version: 1.2.0
 message: If you use this software, please cite it using the metadata from this file.
 type: software
 title: 'lucode2: Code Manipulation and Analysis Tools'
-version: 0.49.3
-date-released: '2025-01-13'
+version: 0.50.0
+date-released: '2025-01-14'
 abstract: A collection of tools which allow to manipulate and analyze code.
 authors:
 - family-names: Dietrich

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Type: Package
 Package: lucode2
 Title: Code Manipulation and Analysis Tools
-Version: 0.49.3
+Version: 0.49.3.9001
 Date: 2025-01-13
 Authors@R: c(
     person("Jan Philipp", "Dietrich", , "dietrich@pik-potsdam.de", role = c("aut", "cre"),

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Type: Package
 Package: lucode2
 Title: Code Manipulation and Analysis Tools
-Version: 0.49.3.9001
-Date: 2025-01-13
+Version: 0.50.0
+Date: 2025-01-14
 Authors@R: c(
     person("Jan Philipp", "Dietrich", , "dietrich@pik-potsdam.de", role = c("aut", "cre"),
            comment = c(affiliation = "Potsdam Institute for Climate Impact Research", ORCID = "0000-0002-4309-6431")),

--- a/R/buildLibrary.R
+++ b/R/buildLibrary.R
@@ -150,12 +150,6 @@ buildLibrary <- function(lib = ".", cran = TRUE, updateType = NULL,
 
   # hidden files in inst/extdata produce NOTE during check, so remove leading dot from .pre-commit-config.yaml
   conditionalCopy(".pre-commit-config.yaml", "pre-commit-config.yaml")
-  if (packageName != "lucode2") {
-    preCommitConfig <- sub("autoupdate_schedule: weekly", "autoupdate_schedule: quarterly",
-                           readLines(".pre-commit-config.yaml"))
-    writeLines(preCommitConfig, ".pre-commit-config.yaml")
-  }
-
   conditionalCopy("Makefile")
 
   ##########################################################

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Code Manipulation and Analysis Tools
 
-R package **lucode2**, version **0.49.3**
+R package **lucode2**, version **0.50.0**
 
 [![CRAN status](https://www.r-pkg.org/badges/version/lucode2)](https://cran.r-project.org/package=lucode2) [![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.4389418.svg)](https://doi.org/10.5281/zenodo.4389418) [![R build status](https://github.com/pik-piam/lucode2/workflows/check/badge.svg)](https://github.com/pik-piam/lucode2/actions) [![codecov](https://codecov.io/gh/pik-piam/lucode2/branch/master/graph/badge.svg)](https://app.codecov.io/gh/pik-piam/lucode2) [![r-universe](https://pik-piam.r-universe.dev/badges/lucode2)](https://pik-piam.r-universe.dev/builds)
 
@@ -39,7 +39,7 @@ In case of questions / problems please contact Jan Philipp Dietrich <dietrich@pi
 
 To cite package **lucode2** in publications use:
 
-Dietrich J, Sauer P, Klein D, Giannousakis A, Bonsch M, Bodirsky B, Baumstark L, Richters O, Pflüger M (2025). "lucode2: Code Manipulation and Analysis Tools." doi:10.5281/zenodo.4389418 <https://doi.org/10.5281/zenodo.4389418>, Version: 0.49.3, <https://github.com/pik-piam/lucode2>.
+Dietrich J, Sauer P, Klein D, Giannousakis A, Bonsch M, Bodirsky B, Baumstark L, Richters O, Pflüger M (2025). "lucode2: Code Manipulation and Analysis Tools." doi:10.5281/zenodo.4389418 <https://doi.org/10.5281/zenodo.4389418>, Version: 0.50.0, <https://github.com/pik-piam/lucode2>.
 
 A BibTeX entry for LaTeX users is
 
@@ -48,9 +48,9 @@ A BibTeX entry for LaTeX users is
   title = {lucode2: Code Manipulation and Analysis Tools},
   author = {Jan Philipp Dietrich and Pascal Sauer and David Klein and Anastasis Giannousakis and Markus Bonsch and Benjamin Leon Bodirsky and Lavinia Baumstark and Oliver Richters and Mika Pflüger},
   doi = {10.5281/zenodo.4389418},
-  date = {2025-01-13},
+  date = {2025-01-14},
   year = {2025},
   url = {https://github.com/pik-piam/lucode2},
-  note = {Version: 0.49.3},
+  note = {Version: 0.50.0},
 }
 ```

--- a/inst/extdata/check.yaml
+++ b/inst/extdata/check.yaml
@@ -66,3 +66,13 @@ jobs:
           if(length(nonDummyTests) > 0 && !lucode2:::loadBuildLibraryConfig()[["skipCoverage"]]) covr::codecov(quiet = FALSE)
         env:
           NOT_CRAN: "true"
+
+  pre-commit:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - uses: actions/setup-python@v5
+      with:
+        python-version: 3
+    - uses: r-lib/actions/setup-r@v2
+    - uses: pre-commit/action@v3.0.1

--- a/inst/extdata/check.yaml
+++ b/inst/extdata/check.yaml
@@ -44,6 +44,8 @@ jobs:
           [ -f requirements.txt ] && python -m pip install --upgrade pip wheel || true
           [ -f requirements.txt ] && pip install -r requirements.txt || true
 
+      - uses: pre-commit/action@v3.0.1
+
       - name: Verify validation key
         shell: Rscript {0}
         run: lucode2:::validkey(stopIfInvalid = TRUE)
@@ -66,13 +68,3 @@ jobs:
           if(length(nonDummyTests) > 0 && !lucode2:::loadBuildLibraryConfig()[["skipCoverage"]]) covr::codecov(quiet = FALSE)
         env:
           NOT_CRAN: "true"
-
-  pre-commit:
-    runs-on: ubuntu-latest
-    steps:
-    - uses: actions/checkout@v4
-    - uses: actions/setup-python@v5
-      with:
-        python-version: 3
-    - uses: r-lib/actions/setup-r@v2
-    - uses: pre-commit/action@v3.0.1

--- a/inst/extdata/check.yaml
+++ b/inst/extdata/check.yaml
@@ -45,6 +45,7 @@ jobs:
           [ -f requirements.txt ] && pip install -r requirements.txt || true
 
       - name: Run pre-commit checks
+        shell: bash
         run: |
           python -m pip install pre-commit
           python -m pip freeze --local

--- a/inst/extdata/check.yaml
+++ b/inst/extdata/check.yaml
@@ -44,7 +44,11 @@ jobs:
           [ -f requirements.txt ] && python -m pip install --upgrade pip wheel || true
           [ -f requirements.txt ] && pip install -r requirements.txt || true
 
-      - uses: pre-commit/action@v3.0.1
+      - name: Run pre-commit checks
+        run: |
+          python -m pip install pre-commit
+          python -m pip freeze --local
+          pre-commit run --show-diff-on-failure --color=always --all-files
 
       - name: Verify validation key
         shell: Rscript {0}


### PR DESCRIPTION
This allows us to get rid of the "pre-commit ci" Github app which automatically creates PRs to update the .pre-commit-config.yaml in all our repos. We want only lucode2 to get these updates and then all our other packages get these via lucode2.