### PR TITLE
Fixes test-updateRepo failure

### DIFF
--- a/.buildlibrary
+++ b/.buildlibrary
@@ -1,4 +1,4 @@
-ValidationKey: '11118091'
+ValidationKey: '11139184'
 AutocreateReadme: yes
 AutocreateCITATION: yes
 AcceptedWarnings:

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -2,8 +2,8 @@ cff-version: 1.2.0
 message: If you use this software, please cite it using the metadata from this file.
 type: software
 title: 'lucode2: Code Manipulation and Analysis Tools'
-version: 0.54.1
-date-released: '2026-04-08'
+version: 0.54.2
+date-released: '2026-04-09'
 abstract: A collection of tools which allow to manipulate and analyze code.
 authors:
 - family-names: Dietrich

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Type: Package
 Package: lucode2
 Title: Code Manipulation and Analysis Tools
-Version: 0.54.1
-Date: 2026-04-08
+Version: 0.54.2
+Date: 2026-04-09
 Authors@R: c(
     person("Jan Philipp", "Dietrich", , "dietrich@pik-potsdam.de", role = c("aut", "cre"),
            comment = c(affiliation = "Potsdam Institute for Climate Impact Research", ORCID = "0000-0002-4309-6431")),

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Code Manipulation and Analysis Tools
 
-R package **lucode2**, version **0.54.1**
+R package **lucode2**, version **0.54.2**
 
 [![CRAN status](https://www.r-pkg.org/badges/version/lucode2)](https://cran.r-project.org/package=lucode2) [![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.4389418.svg)](https://doi.org/10.5281/zenodo.4389418) [![R build status](https://github.com/pik-piam/lucode2/workflows/check/badge.svg)](https://github.com/pik-piam/lucode2/actions) [![codecov](https://codecov.io/gh/pik-piam/lucode2/branch/master/graph/badge.svg)](https://app.codecov.io/gh/pik-piam/lucode2) [![r-universe](https://pik-piam.r-universe.dev/badges/lucode2)](https://pik-piam.r-universe.dev/builds)
 
@@ -39,7 +39,7 @@ In case of questions / problems please contact Jan Philipp Dietrich <dietrich@pi
 
 To cite package **lucode2** in publications use:
 
-Dietrich J, Sauer P, Klein D, Giannousakis A, Bonsch M, Bodirsky B, Baumstark L, Richters O, Pflüger M, Rein P (2026). "lucode2: Code Manipulation and Analysis Tools." doi:10.5281/zenodo.4389418 <https://doi.org/10.5281/zenodo.4389418>, Version: 0.54.1, <https://github.com/pik-piam/lucode2>.
+Dietrich J, Sauer P, Klein D, Giannousakis A, Bonsch M, Bodirsky B, Baumstark L, Richters O, Pflüger M, Rein P (2026). "lucode2: Code Manipulation and Analysis Tools." doi:10.5281/zenodo.4389418 <https://doi.org/10.5281/zenodo.4389418>, Version: 0.54.2, <https://github.com/pik-piam/lucode2>.
 
 A BibTeX entry for LaTeX users is
 
@@ -48,9 +48,9 @@ A BibTeX entry for LaTeX users is
   title = {lucode2: Code Manipulation and Analysis Tools},
   author = {Jan Philipp Dietrich and Pascal Sauer and David Klein and Anastasis Giannousakis and Markus Bonsch and Benjamin Leon Bodirsky and Lavinia Baumstark and Oliver Richters and Mika Pflüger and Patrick Rein},
   doi = {10.5281/zenodo.4389418},
-  date = {2026-04-08},
+  date = {2026-04-09},
   year = {2026},
   url = {https://github.com/pik-piam/lucode2},
-  note = {Version: 0.54.1},
+  note = {Version: 0.54.2},
 }
 ```

--- a/tests/testthat/test-updateRepo.R
+++ b/tests/testthat/test-updateRepo.R
@@ -1,8 +1,14 @@
 test_that("updateRepo works", {
   capture.output({
-    reposFolder <- withr::local_tempdir()
+    baseFolder <- withr::local_tempdir()
+    reposFolder <- file.path(baseFolder, "repos")
+    miniPackageRepo <- file.path(baseFolder, "repo-miniPackage")
 
-    gert::git_clone("https://github.com/pik-piam/miniPackage.git",
+    # The following indirection via a local repo makes this test less
+    # susceptible to system-local libgit issues.
+    system(paste0("git clone --depth=1 https://github.com/pik-piam/miniPackage.git", " ", miniPackageRepo),
+           ignore.stdout = TRUE, ignore.stderr = TRUE)
+    gert::git_clone(miniPackageRepo,
                     file.path(reposFolder, "miniPackage"),
                     verbose = FALSE)
     expect_message({


### PR DESCRIPTION
This PR (hopefully) fixes the r-universe failure of `test-updateRepo`. It does so by using a local repo to set up the repos folder. The local repo is initialized using the system-level git.