### PR TITLE
Speed up CI by using a pre-built docker image

### DIFF
--- a/.buildlibrary
+++ b/.buildlibrary
@@ -1,4 +1,4 @@
-ValidationKey: '11211740'
+ValidationKey: '11317900'
 AutocreateReadme: yes
 AutocreateCITATION: yes
 AcceptedWarnings:

--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -11,42 +11,22 @@ jobs:
   check:
     runs-on: ubuntu-latest
     if: github.event.pull_request.draft == false
+    container:
+      image: ghcr.io/pik-piam/ci-image:latest
 
     steps:
       - uses: actions/checkout@v4
 
-      - uses: r-lib/actions/setup-pandoc@v2
-
-      # We fix this to 4.5, as currently, pre-commit hooks do not
-      # work reliably with 4.6 because of Rcpp not building reliably
-      # on 4.6. When this is resolved, the version constraint should
-      # be removed again.
-      - uses: r-lib/actions/setup-r@v2
-        with:
-          use-public-rspm: true
-          extra-repositories: "https://rse.pik-potsdam.de/r/packages"
-          r-version: 4.5
-
-      - uses: r-lib/actions/setup-r-dependencies@v2
-        with:
-          extra-packages: |
-            lucode2
-            covr
-            madrat
-            magclass
-            citation
-            gms
-            goxygen
-            GDPuc
-          # piam packages also available on CRAN (madrat, magclass, citation,
-          # gms, goxygen, GDPuc) will usually have an outdated binary version
-          # available; by using extra-packages we get the newest version
-
+      - name: Install
+        shell: Rscript {0}
+        run: |
+          options(repos = c(pikpiam = 'https://pik-piam.r-universe.dev',
+                            CRAN = Sys.getenv('RSPM')))
+          pak::pak()
+          
       - name: Run pre-commit checks
         shell: bash
         run: |
-          python -m pip install pre-commit
-          python -m pip freeze --local
           pre-commit run --show-diff-on-failure --color=always --all-files
 
       - name: Verify validation key

--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -17,7 +17,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Install
+      - name: Install package and dependencies
         shell: Rscript {0}
         run: |
           options(repos = c(pikpiam = 'https://pik-piam.r-universe.dev',

--- a/.github/workflows/pkgdown.yaml
+++ b/.github/workflows/pkgdown.yaml
@@ -18,20 +18,17 @@ jobs:
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
     permissions:
       contents: write
+    container:
+      image: ghcr.io/pik-piam/ci-image:latest
     steps:
       - uses: actions/checkout@v4
 
-      - uses: r-lib/actions/setup-pandoc@v2
-
-      - uses: r-lib/actions/setup-r@v2
-        with:
-          use-public-rspm: true
-          extra-repositories: "https://rse.pik-potsdam.de/r/packages"
-
-      - uses: r-lib/actions/setup-r-dependencies@v2
-        with:
-          extra-packages: any::pkgdown, local::.
-          needs: website
+      - name: Install
+        shell: Rscript {0}
+        run: |
+          options(repos = c(pikpiam = 'https://pik-piam.r-universe.dev',
+                            CRAN = Sys.getenv('RSPM')))
+          pak::pak(dependencies = c("all", "website"))
 
       - name: Build site
         run: pkgdown::build_site_github_pages(new_process = FALSE, install = FALSE)

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -2,8 +2,8 @@ cff-version: 1.2.0
 message: If you use this software, please cite it using the metadata from this file.
 type: software
 title: 'lucode2: Code Manipulation and Analysis Tools'
-version: 0.54.5
-date-released: '2026-04-29'
+version: 0.55.0
+date-released: '2026-05-05'
 abstract: A collection of tools which allow to manipulate and analyze code.
 authors:
 - family-names: Dietrich

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Type: Package
 Package: lucode2
 Title: Code Manipulation and Analysis Tools
-Version: 0.54.5
-Date: 2026-04-29
+Version: 0.55.0
+Date: 2026-05-05
 Authors@R: c(
     person("Jan Philipp", "Dietrich", , "dietrich@pik-potsdam.de", role = c("aut", "cre"),
            comment = c(affiliation = "Potsdam Institute for Climate Impact Research", ORCID = "0000-0002-4309-6431")),

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Code Manipulation and Analysis Tools
 
-R package **lucode2**, version **0.54.5**
+R package **lucode2**, version **0.55.0**
 
   [![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.4389418.svg)](https://doi.org/10.5281/zenodo.4389418) [![R build status](https://github.com/pik-piam/lucode2/workflows/check/badge.svg)](https://github.com/pik-piam/lucode2/actions) [![codecov](https://codecov.io/gh/pik-piam/lucode2/branch/master/graph/badge.svg)](https://app.codecov.io/gh/pik-piam/lucode2) [![r-universe](https://pik-piam.r-universe.dev/badges/lucode2)](https://pik-piam.r-universe.dev/builds)
 
@@ -39,7 +39,7 @@ In case of questions / problems please contact Jan Philipp Dietrich <dietrich@pi
 
 To cite package **lucode2** in publications use:
 
-Dietrich J, Sauer P, Klein D, Giannousakis A, Bonsch M, Bodirsky B, Baumstark L, Richters O, Pflüger M, Rein P (2026). "lucode2: Code Manipulation and Analysis Tools." doi:10.5281/zenodo.4389418 <https://doi.org/10.5281/zenodo.4389418>, Version: 0.54.5, <https://github.com/pik-piam/lucode2>.
+Dietrich J, Sauer P, Klein D, Giannousakis A, Bonsch M, Bodirsky B, Baumstark L, Richters O, Pflüger M, Rein P (2026). "lucode2: Code Manipulation and Analysis Tools." doi:10.5281/zenodo.4389418 <https://doi.org/10.5281/zenodo.4389418>, Version: 0.55.0, <https://github.com/pik-piam/lucode2>.
 
 A BibTeX entry for LaTeX users is
 
@@ -48,9 +48,9 @@ A BibTeX entry for LaTeX users is
   title = {lucode2: Code Manipulation and Analysis Tools},
   author = {Jan Philipp Dietrich and Pascal Sauer and David Klein and Anastasis Giannousakis and Markus Bonsch and Benjamin Leon Bodirsky and Lavinia Baumstark and Oliver Richters and Mika Pflüger and Patrick Rein},
   doi = {10.5281/zenodo.4389418},
-  date = {2026-04-29},
+  date = {2026-05-05},
   year = {2026},
   url = {https://github.com/pik-piam/lucode2},
-  note = {Version: 0.54.5},
+  note = {Version: 0.55.0},
 }
 ```

--- a/inst/extdata/check.yaml
+++ b/inst/extdata/check.yaml
@@ -11,42 +11,22 @@ jobs:
   check:
     runs-on: ubuntu-latest
     if: github.event.pull_request.draft == false
+    container:
+      image: ghcr.io/pik-piam/ci-image:latest
 
     steps:
       - uses: actions/checkout@v4
 
-      - uses: r-lib/actions/setup-pandoc@v2
-
-      # We fix this to 4.5, as currently, pre-commit hooks do not
-      # work reliably with 4.6 because of Rcpp not building reliably
-      # on 4.6. When this is resolved, the version constraint should
-      # be removed again.
-      - uses: r-lib/actions/setup-r@v2
-        with:
-          use-public-rspm: true
-          extra-repositories: "https://rse.pik-potsdam.de/r/packages"
-          r-version: 4.5
-
-      - uses: r-lib/actions/setup-r-dependencies@v2
-        with:
-          extra-packages: |
-            lucode2
-            covr
-            madrat
-            magclass
-            citation
-            gms
-            goxygen
-            GDPuc
-          # piam packages also available on CRAN (madrat, magclass, citation,
-          # gms, goxygen, GDPuc) will usually have an outdated binary version
-          # available; by using extra-packages we get the newest version
-
+      - name: Install
+        shell: Rscript {0}
+        run: |
+          options(repos = c(pikpiam = 'https://pik-piam.r-universe.dev',
+                            CRAN = Sys.getenv('RSPM')))
+          pak::pak()
+          
       - name: Run pre-commit checks
         shell: bash
         run: |
-          python -m pip install pre-commit
-          python -m pip freeze --local
           pre-commit run --show-diff-on-failure --color=always --all-files
 
       - name: Verify validation key

--- a/inst/extdata/check.yaml
+++ b/inst/extdata/check.yaml
@@ -17,7 +17,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Install
+      - name: Install package and dependencies
         shell: Rscript {0}
         run: |
           options(repos = c(pikpiam = 'https://pik-piam.r-universe.dev',

--- a/inst/extdata/pkgdown.yaml
+++ b/inst/extdata/pkgdown.yaml
@@ -18,20 +18,17 @@ jobs:
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
     permissions:
       contents: write
+    container:
+      image: ghcr.io/pik-piam/ci-image:latest
     steps:
       - uses: actions/checkout@v4
 
-      - uses: r-lib/actions/setup-pandoc@v2
-
-      - uses: r-lib/actions/setup-r@v2
-        with:
-          use-public-rspm: true
-          extra-repositories: "https://rse.pik-potsdam.de/r/packages"
-
-      - uses: r-lib/actions/setup-r-dependencies@v2
-        with:
-          extra-packages: any::pkgdown, local::.
-          needs: website
+      - name: Install
+        shell: Rscript {0}
+        run: |
+          options(repos = c(pikpiam = 'https://pik-piam.r-universe.dev',
+                            CRAN = Sys.getenv('RSPM')))
+          pak::pak(dependencies = c("all", "website"))
 
       - name: Build site
         run: pkgdown::build_site_github_pages(new_process = FALSE, install = FALSE)


### PR DESCRIPTION
This PR introduces a pre-built docker image for CI to speed up jobs. It is based on the new repository for docker images: https://github.com/pik-piam/piam-docker

The main change is using the container in the jobs and removing the setup steps that install R, pandoc, and pre-commit. All three are already present in the image. The package to be built is still installed afresh, but the image already contains many R and OS dependencies pre-installed, which also speeds up things.