### PR TITLE
Fixes fast pkgdown action

### DIFF
--- a/.buildlibrary
+++ b/.buildlibrary
@@ -1,4 +1,4 @@
-ValidationKey: '11341784'
+ValidationKey: '11362920'
 AutocreateReadme: yes
 AutocreateCITATION: yes
 AcceptedWarnings:

--- a/.github/workflows/pkgdown.yaml
+++ b/.github/workflows/pkgdown.yaml
@@ -28,7 +28,7 @@ jobs:
         run: |
           options(repos = c(pikpiam = 'https://pik-piam.r-universe.dev',
                             CRAN = Sys.getenv('RSPM')))
-          pak::pak()
+          pak::pak(".")
           pak::pkg_install("tidyverse/tidytemplate")
 
       - name: Build site

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -2,8 +2,8 @@ cff-version: 1.2.0
 message: If you use this software, please cite it using the metadata from this file.
 type: software
 title: 'lucode2: Code Manipulation and Analysis Tools'
-version: 0.55.1
-date-released: '2026-05-11'
+version: 0.55.2
+date-released: '2026-05-12'
 abstract: A collection of tools which allow to manipulate and analyze code.
 authors:
 - family-names: Dietrich

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Type: Package
 Package: lucode2
 Title: Code Manipulation and Analysis Tools
-Version: 0.55.1
-Date: 2026-05-11
+Version: 0.55.2
+Date: 2026-05-12
 Authors@R: c(
     person("Jan Philipp", "Dietrich", , "dietrich@pik-potsdam.de", role = c("aut", "cre"),
            comment = c(affiliation = "Potsdam Institute for Climate Impact Research", ORCID = "0000-0002-4309-6431")),

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Code Manipulation and Analysis Tools
 
-R package **lucode2**, version **0.55.1**
+R package **lucode2**, version **0.55.2**
 
   [![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.4389418.svg)](https://doi.org/10.5281/zenodo.4389418) [![R build status](https://github.com/pik-piam/lucode2/workflows/check/badge.svg)](https://github.com/pik-piam/lucode2/actions) [![codecov](https://codecov.io/gh/pik-piam/lucode2/branch/master/graph/badge.svg)](https://app.codecov.io/gh/pik-piam/lucode2) [![r-universe](https://pik-piam.r-universe.dev/badges/lucode2)](https://pik-piam.r-universe.dev/builds)
 
@@ -39,7 +39,7 @@ In case of questions / problems please contact Jan Philipp Dietrich <dietrich@pi
 
 To cite package **lucode2** in publications use:
 
-Dietrich J, Sauer P, Klein D, Giannousakis A, Bonsch M, Bodirsky B, Baumstark L, Richters O, Pflüger M, Rein P (2026). "lucode2: Code Manipulation and Analysis Tools." doi:10.5281/zenodo.4389418 <https://doi.org/10.5281/zenodo.4389418>, Version: 0.55.1, <https://github.com/pik-piam/lucode2>.
+Dietrich J, Sauer P, Klein D, Giannousakis A, Bonsch M, Bodirsky B, Baumstark L, Richters O, Pflüger M, Rein P (2026). "lucode2: Code Manipulation and Analysis Tools." doi:10.5281/zenodo.4389418 <https://doi.org/10.5281/zenodo.4389418>, Version: 0.55.2, <https://github.com/pik-piam/lucode2>.
 
 A BibTeX entry for LaTeX users is
 
@@ -48,9 +48,9 @@ A BibTeX entry for LaTeX users is
   title = {lucode2: Code Manipulation and Analysis Tools},
   author = {Jan Philipp Dietrich and Pascal Sauer and David Klein and Anastasis Giannousakis and Markus Bonsch and Benjamin Leon Bodirsky and Lavinia Baumstark and Oliver Richters and Mika Pflüger and Patrick Rein},
   doi = {10.5281/zenodo.4389418},
-  date = {2026-05-11},
+  date = {2026-05-12},
   year = {2026},
   url = {https://github.com/pik-piam/lucode2},
-  note = {Version: 0.55.1},
+  note = {Version: 0.55.2},
 }
 ```

--- a/inst/extdata/pkgdown.yaml
+++ b/inst/extdata/pkgdown.yaml
@@ -28,7 +28,7 @@ jobs:
         run: |
           options(repos = c(pikpiam = 'https://pik-piam.r-universe.dev',
                             CRAN = Sys.getenv('RSPM')))
-          pak::pak()
+          pak::pak(".")
           pak::pkg_install("tidyverse/tidytemplate")
 
       - name: Build site


### PR DESCRIPTION
In the new pkgdown action, install local package instead of only local package dependencies, as pkgdown expects package to be installed